### PR TITLE
feat(Sales Invoice): add bank details

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Please use a branch (`MAJOR_VERSION`) that matches the major version of ERPNext 
 
 ## Setup
 
+### Code Lists
+
 E-invoices rely on common codes that describe the content of the invoice. E.g. "C62" is used for the UOM "One" and "ZZZ" is used for a mutually agreed mode of payment.
 
 Common codes are part of a code list. You'll need to import the code lists and map the codes you need to the corresponding ERPNext entities. Please use the "Import Genericode" button in **Code List** and paste the URL linked below.
@@ -46,6 +48,14 @@ The retrieval of codes goes from the most specific to the most general. E.g. for
 ### Buyer Reference (German: Leitweg-ID)
 
 If you work with government customers or similar large organizations, you might need to specify their _Buyer Reference_ in the eInvoice. This is done by setting the _Buyer Reference_ field in the **Sales Invoice**. You can already fill this field in the **Customer** master data or the **Sales Order**.
+
+### Bank Details
+
+If you want your eInvoice to contain bank details, you need to set up a **Mode of Payment** of type "Bank", link the company's corresponding **Account** and create a **Bank Account** for the same account.
+
+Then, you can map a **Common Code** from **Code List** "UNTDID.4461", e.g. "Credit Transfer" (30) or "SEPA Credit Transfer" (58), to the **Mode of Payment**.
+
+Please note that the eInvoice standard only supports one payment means per invoice, so you should not specify multiple **Modes of Payment** in the same invoice.
 
 ## Usage
 
@@ -117,6 +127,10 @@ The following fields of the **Sales Invoice** are currently considered for the e
 - Terms and Conditions Details (converted to markdown)
 - Incoterm and named place
 - Payment Schedule
+    - Mode of Payment -> Account -> Bank Account
+        - IBAN
+        - Bank
+            - SWIFT Number
     - Description
     - Due date
     - Amount

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -694,11 +694,15 @@ def get_bank_details(mode_of_payment: str, company: str) -> tuple[str | None, st
 	if frappe.db.get_value("Mode of Payment", mode_of_payment, "type") != "Bank":
 		return empty_tuple
 
-	account = frappe.db.get_value("Mode of Payment Account", {"parent": mode_of_payment, "company": company}, "default_account")
+	account = frappe.db.get_value(
+		"Mode of Payment Account", {"parent": mode_of_payment, "company": company}, "default_account"
+	)
 	if not account:
 		return empty_tuple
 
-	bank_account_name = frappe.db.get_value("Bank Account", {"account": account, "company": company, "is_company_account": 1, "disabled": 0})
+	bank_account_name = frappe.db.get_value(
+		"Bank Account", {"account": account, "company": company, "is_company_account": 1, "disabled": 0}
+	)
 	if not bank_account_name:
 		return empty_tuple
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -606,6 +606,7 @@ def validate_doc(doc, event):
 				indicator="orange",
 			)
 
+	modes_of_payment = set()
 	for ps in doc.payment_schedule:
 		if ps.discount_date and date_diff(ps.discount_date, doc.posting_date) < 0:
 			frappe.msgprint(
@@ -615,6 +616,18 @@ def validate_doc(doc, event):
 				alert=True,
 				indicator="orange",
 			)
+
+		if ps.mode_of_payment:
+			modes_of_payment.add(ps.mode_of_payment)
+
+	if len(modes_of_payment) > 1:
+		frappe.msgprint(
+			_("{0}: Only one mode of payment will be considered in the e-invoice.").format(
+				_(doc.meta.get_label("payment_schedule"))
+			),
+			alert=True,
+			indicator="orange",
+		)
 
 	validate_einvoice(doc)
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -136,10 +136,7 @@ class EInvoiceGenerator:
 			self._add_empty_tax()
 
 		self.doc.trade.settlement.currency_code = self.invoice.currency
-		self.doc.trade.settlement.payment_means.type_code = payment_means_codes.get(
-			[("Payment Terms Template", self.invoice.payment_terms_template)]
-			+ [("Mode of Payment", term.mode_of_payment) for term in self.invoice.payment_schedule]
-		)
+		self._add_payment_means()
 
 		if self.invoice.from_date:
 			self.doc.trade.settlement.period.start = getdate(self.invoice.from_date)
@@ -532,6 +529,26 @@ class EInvoiceGenerator:
 
 			self.doc.trade.settlement.terms.add(payment_terms)
 
+	def _add_payment_means(self):
+		self.doc.trade.settlement.payment_means.type_code = payment_means_codes.get(
+			[("Payment Terms Template", self.invoice.payment_terms_template)]
+			+ [("Mode of Payment", term.mode_of_payment) for term in self.invoice.payment_schedule]
+		)
+
+		modes_of_payment = {ps.mode_of_payment for ps in self.invoice.payment_schedule if ps.mode_of_payment}
+		for mode_of_payment in modes_of_payment:
+			iban, bic = get_bank_details(mode_of_payment, self.invoice.company)
+			if not iban:
+				continue
+
+			self.doc.trade.settlement.payment_means.payee_account.iban = iban
+
+			if self.profile >= EInvoiceProfile.EN16931:
+				self.doc.trade.settlement.payment_means.payee_account.account_name = self.invoice.company
+				self.doc.trade.settlement.payment_means.payee_institution.bic = bic
+
+			break
+
 	def _set_totals(self):
 		actual_charge_total = sum(tax.tax_amount for tax in self.invoice.taxes if tax.charge_type == "Actual")
 		tax_total = sum(tax.tax_amount for tax in self.invoice.taxes if tax.charge_type != "Actual")
@@ -656,6 +673,28 @@ def get_skonto_line(days: int, percent: float, basis_amount: float | None = None
 		parts.append(f"BASISBETRAG={basis_amount:.2f}")
 
 	return "#" + "#".join(parts) + "#"
+
+
+def get_bank_details(mode_of_payment: str, company: str) -> tuple[str | None, str | None]:
+	"""Get the bank details for a mode of payment."""
+	empty_tuple = (None, None)
+	if frappe.db.get_value("Mode of Payment", mode_of_payment, "type") != "Bank":
+		return empty_tuple
+
+	account = frappe.db.get_value("Mode of Payment Account", {"parent": mode_of_payment, "company": company}, "default_account")
+	if not account:
+		return empty_tuple
+
+	bank_account_name = frappe.db.get_value("Bank Account", {"account": account, "company": company, "is_company_account": 1, "disabled": 0})
+	if not bank_account_name:
+		return empty_tuple
+
+	iban, bank = frappe.db.get_value("Bank Account", bank_account_name, ["iban", "bank"])
+	if not iban:
+		return empty_tuple
+
+	bic = frappe.db.get_value("Bank", bank, "swift_number") if bank else None
+	return (iban, bic or None)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2024-12-12 00:15+0053\n"
+"POT-Creation-Date: 2024-12-30 15:34+0053\n"
 "PO-Revision-Date: 2024-11-25 18:57+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -110,11 +110,11 @@ msgstr "Berechneter Betrag"
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:570
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:642
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:576
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:648
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
@@ -481,11 +481,15 @@ msgstr "Validierungsfehler"
 msgid "View {0}"
 msgstr "{0} ansehen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:553
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:613
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:543
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:602
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:625
+msgid "{0}: Only one mode of payment will be considered in the e-invoice."
+msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2024-12-12 00:15+0053\n"
-"PO-Revision-Date: 2024-12-12 00:15+0053\n"
+"POT-Creation-Date: 2024-12-30 15:34+0053\n"
+"PO-Revision-Date: 2024-12-30 15:34+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -108,11 +108,11 @@ msgstr ""
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:570
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:642
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:576
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:648
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
@@ -479,11 +479,15 @@ msgstr ""
 msgid "View {0}"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:553
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:613
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:543
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:602
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:625
+msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 


### PR DESCRIPTION
E-Invoice generation:

* Added the `_add_payment_means` method to set the payment means type code and retrieve bank details based on the mode of payment.
* Updated the `create_einvoice` method to use the new `_add_payment_means` method.

**Sales Invoice** validation:

* Modified the `validate_doc` method to display an alert if multiple modes of payment are specified.

README:

* Added sections on "Code Lists" and "Bank Details" to guide users on setting up eInvoices with the necessary codes and bank details.
* Updated the list of fields considered for the eInvoice to include bank details.
* Updated translation files to reflect changes in the codebase.


Towards #19