### PR TITLE
fix: add AppliedTradeTax to LogisticsServiceCharge

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - Discount
     - Discount Date
 - Sales Taxs and Charges
-    - The _Charge Type_ "Actual" is used as logistics or service charges.
+    - The _Charge Type_ "Actual" is used as logistics or service charges. If you want to add VAT for the service charge, you need to add a _Charge Type_ "On Previous Row Amount" or "On Previous Row Total" immediately after the service charge.
     - For _Charge Type_ "On Net Total", the taxable amount is calculated as `tax_amount / rate * 100`, if the rate is available in the tax row or in the corresponding Account [1].
     - The _Charge Type_ "On Item Quantity" is not supported.
 - Total

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - Discount
     - Discount Date
 - Sales Taxs and Charges
-    - The _Charge Type_ "Actual" is used as logistics or service charges. If you want to add VAT for the service charge, you need to add a _Charge Type_ "On Previous Row Amount" or "On Previous Row Total" immediately after the service charge.
+    - The _Charge Type_ "Actual" is used as logistics or service charges. It is only supported by the eInvoice profiles "EXTENDED" and "XRECHNUNG". If you want to add VAT for the service charge, you need to add a _Charge Type_ "On Previous Row Amount" or "On Previous Row Total" immediately after the service charge.
     - For _Charge Type_ "On Net Total", the taxable amount is calculated as `tax_amount / rate * 100`, if the rate is available in the tax row or in the corresponding Account [1].
     - The _Charge Type_ "On Item Quantity" is not supported.
 - Total

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -4,7 +4,7 @@ import re
 from typing import TYPE_CHECKING
 
 import frappe
-from drafthorse.models.accounting import ApplicableTradeTax
+from drafthorse.models.accounting import ApplicableTradeTax, AppliedTradeTax
 from drafthorse.models.document import Document, IncludedNote
 from drafthorse.models.party import TaxRegistration, URIUniversalCommunication
 from drafthorse.models.payment import PaymentTerms
@@ -385,6 +385,27 @@ class EInvoiceGenerator:
 				service_charge = LogisticsServiceCharge()
 				service_charge.description = tax.description
 				service_charge.applied_amount = tax.tax_amount
+
+				# Add VAT for the service charge to prevent BR-FXEXT-S-08
+				try:
+					vat_line = self.invoice.taxes[i + 1]
+					if vat_line.charge_type in ("On Previous Row Amount", "On Previous Row Total"):
+						service_charge_tax = AppliedTradeTax()
+						service_charge_tax.type_code = "VAT"
+						service_charge_tax.rate_applicable_percent = vat_line.rate
+						service_charge_tax.category_code = duty_tax_fee_category_codes.get(
+							[
+								("Account", vat_line.account_head),
+								("Tax Category", self.invoice.tax_category),
+								("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
+							]
+						)
+						service_charge.trade_tax.add(service_charge_tax)
+				except IndexError:
+					# No VAT line after the service charge
+					# can still be valid if no tax is applied
+					pass
+
 				self.doc.trade.settlement.service_charge.add(service_charge)
 			elif tax.charge_type == "On Net Total":
 				trade_tax = ApplicableTradeTax()

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -381,7 +381,7 @@ class EInvoiceGenerator:
 			if not tax.tax_amount:
 				continue
 
-			if tax.charge_type == "Actual":
+			if tax.charge_type == "Actual" and self.profile >= EInvoiceProfile.EXTENDED:
 				service_charge = LogisticsServiceCharge()
 				service_charge.description = tax.description
 				service_charge.applied_amount = tax.tax_amount
@@ -619,6 +619,18 @@ def validate_doc(doc, event):
 				_("{0} row #{1}: Type '{2}' is not supported in e-invoice").format(
 					_(doc.meta.get_label("taxes")), tax_row.idx, _(tax_row.charge_type)
 				),
+				alert=True,
+				indicator="orange",
+			)
+
+		if (
+			tax_row.charge_type == "Actual"
+			and EInvoiceProfile(doc.einvoice_profile) < EInvoiceProfile.EXTENDED
+		):
+			frappe.msgprint(
+				_(
+					"{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
+				).format(_(doc.meta.get_label("taxes")), tax_row.idx),
 				alert=True,
 				indicator="orange",
 			)

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -386,10 +386,10 @@ class EInvoiceGenerator:
 				service_charge.description = tax.description
 				service_charge.applied_amount = tax.tax_amount
 
-				# Add VAT for the service charge to prevent BR-FXEXT-S-08
-				try:
+				if len(self.invoice.taxes) > i + 1:
 					vat_line = self.invoice.taxes[i + 1]
 					if vat_line.charge_type in ("On Previous Row Amount", "On Previous Row Total"):
+						# Add applied VAT for the service charge (BR-FXEXT-S-08)
 						service_charge_tax = AppliedTradeTax()
 						service_charge_tax.type_code = "VAT"
 						service_charge_tax.rate_applicable_percent = vat_line.rate
@@ -401,10 +401,6 @@ class EInvoiceGenerator:
 							]
 						)
 						service_charge.trade_tax.add(service_charge_tax)
-				except IndexError:
-					# No VAT line after the service charge
-					# can still be valid if no tax is applied
-					pass
 
 				self.doc.trade.settlement.service_charge.add(service_charge)
 			elif tax.charge_type == "On Net Total":


### PR DESCRIPTION
Adding shipping costs as taxes with charge type "Actual" and VAT on the next line with charge type "On Previous Row Amount" or "On Previous Row Total" will produce an invalid e-invoice xml file with the extended profile.

The validation on import in erpnext will fail with the error 
```
[BR-FXEXT-S-08]-For each different value of VAT category rate (BT-119) where the VAT category code (BT-118) is equal to “S” ("Standard rated"), Absolute Value of (VAT category taxable amount (BT-116) - ∑ Invoice line net amounts (BT-131) + Σ Document level allowance amounts (BT-92) - Σ Document level charges amounts (BT-99) - Σ Logistics Service fee amounts (BT-x-272)) <= 0,01 * ((Number of line net amounts (BT-131) + Number of Document level allowance amounts (BT-92) + Number of Document level charge amounts (BT-99) + Number of Logistics Service fee amounts (BT-X-272)), where the VAT category code (BT-151, BT-95, BT-102, BT-X-273) is "Standard rated" (S) and the VAT rate (BT-152, BT-96, BT-103, BT-X-274) equals the VAT category rate (BT-119).
Element 'ram:AppliedTradeTax' must occur at least 1 times.
```

In order to fix this, output SpecifiedLogisticsServiceCharge with AppliedTradeTax.
```xml
      <ram:SpecifiedLogisticsServiceCharge>
        <ram:Description>DHL Paket bis 5 kg</ram:Description>
        <ram:AppliedAmount>5.99</ram:AppliedAmount>
        <ram:AppliedTradeTax>
          <ram:TypeCode>VAT</ram:TypeCode>
          <ram:CategoryCode>S</ram:CategoryCode>
          <ram:RateApplicablePercent>19.0</ram:RateApplicablePercent>
        </ram:AppliedTradeTax>
      </ram:SpecifiedLogisticsServiceCharge>
```