### PR TITLE
feat(Sales Invoice): Convert the PDF data to PDF/A-3 using ghostscript.

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -810,8 +810,8 @@ def _get_icc_profile_path() -> str:
 	if not search_paths:
 		raise RuntimeError("Unable to find /lib path in Ghostscript search paths")
 
-	path = search_paths.group(2).strip()
-	icc_path = os.path.join(path[:-4], "iccprofiles")
+	library_path = search_paths.group(2).strip()
+	icc_path = os.path.join(library_path[:-4], "iccprofiles")
 
 	if not os.path.exists(icc_path):
 		raise RuntimeError("Unable to find ICC profiles folder in Ghostscript search paths.")
@@ -828,13 +828,14 @@ def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 	cwd = None
 	if not os.path.isfile("srgb.icc"):
 		# the PDFA_def.ps file requires the srgb.icc file to be present in the current directory
-		# if it is not present, change the current working directory to the Ghostscript installation
+		# if it is not present, change the current working directory to the icc profile path.
 		cwd = _get_icc_profile_path()
 
 	with subprocess.Popen(
 		[
 			"gs",
 			"-q",
+			"-sstdout=%stderr",
 			"-dPDFA=3",
 			"-dBATCH",
 			"-dNOPAUSE",

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -785,6 +785,73 @@ def download_pdf(
 			frappe.local.response.filecontent = zugferd_pdf
 
 
+def _create_symlink_to_icc_profile():
+	"""Create a symlink to the ICC profile in the Ghostscript installation."""
+	import os
+	import re
+	import subprocess
+
+	gs_output = subprocess.run(["gs", "-h"], capture_output=True, text=True)
+	search_paths = re.findall(r"Search path:\n([0-9a-zA-Z\/ :.\n]+)Ghostscript", gs_output.stdout, re.DOTALL)
+	search_paths = search_paths[0].replace("\n", "").strip()
+	lib_path = None
+	paths = search_paths.split(":")
+	for path in paths:
+		if path.strip().endswith("/lib"):
+			lib_path = path.strip()[:-4]
+			break
+	if lib_path:
+		icc_path = os.path.join(lib_path, "iccprofiles/srgb.icc")
+		if os.path.isfile(icc_path):
+			os.symlink(icc_path, "srgb.icc")
+			return
+
+	raise RuntimeError("Unable to find ICC profile in Ghostscript search paths")
+
+
+def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
+	"""Convert the PDF data to PDF/A-3 using Ghostscript."""
+	import os
+	import re
+	import subprocess
+
+	if not os.path.isfile("srgb.icc"):
+		# the PDFA_def.ps file requires the srgb.icc file to be present in the current directory
+		# if it is not present, we create a symlink to the srgb.icc file in the Ghostscript installation
+		_create_symlink_to_icc_profile()
+
+	with subprocess.Popen(
+		[
+			"gs",
+			"-q",
+			"-dPDFA=3",
+			"-dBATCH",
+			"-dNOPAUSE",
+			"-dPDFACompatibilityPolicy=1",
+			"-sColorConversionStrategy=RGB",
+			"--permit-file-read=srgb.icc",
+			"-sDEVICE=pdfwrite",
+			"-sOutputFile=-",
+			"PDFA_def.ps",
+			"-",
+		],
+		stdin=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+	) as proc:
+		pdfa_data, err = proc.communicate(input=pdf_data)
+		if proc.returncode != 0:
+			raise RuntimeError(f"Ghostscript error: {err.decode()}")
+		return pdfa_data
+
+
+def _is_ghostscript_installed():
+	"""Check if Ghostscript is installed on the system."""
+	import shutil
+
+	return shutil.which("gs") is not None
+
+
 def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 	"""Return the PDF data with the invoice attached as XML.
 
@@ -793,6 +860,9 @@ def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 	    pdf_data: The PDF data as bytes.
 	"""
 	from drafthorse.pdf import attach_xml
+
+	if _is_ghostscript_installed():
+		pdf_data = _convert_pdf_to_pdfa(pdf_data)
 
 	level = frappe.db.get_value("Sales Invoice", invoice_id, "einvoice_profile")
 	if level == "XRECHNUNG":

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -804,16 +804,17 @@ def _get_icc_profile_path() -> str:
 	#   /usr/local/lib/ghostscript/fonts : /usr/share/fonts
 	# Ghostscript is also using fontconfig to search for font files
 	# ...
-	search_paths = re.search(r"Search path:\n(.*?)Ghostscript", gs_output.stdout, re.DOTALL)
+	search_paths = re.search(
+		r"Search path:([\s\S]+) (\/.+\/lib) ([\s\S]+)Ghostscript", gs_output.stdout, re.DOTALL
+	)
 	if not search_paths:
-		raise RuntimeError("Unable to find Ghostscript search paths")
+		raise RuntimeError("Unable to find /lib path in Ghostscript search paths")
 
-	for path in search_paths.group(1).split(":"):
-		path = path.strip()
-		if path.endswith("/lib"):
-			icc_path = os.path.join(path[:-4], "iccprofiles")
-			if os.path.exists(icc_path):
-				return icc_path
+	if search_paths:
+		path = search_paths.group(2).strip()
+		icc_path = os.path.join(path[:-4], "iccprofiles")
+		if os.path.exists(icc_path):
+			return icc_path
 
 	raise RuntimeError("Unable to find ICC profiles folder in Ghostscript search paths.")
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -822,7 +822,6 @@ def _get_icc_profile_path() -> str:
 def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 	"""Convert the PDF data to PDF/A-3 using Ghostscript."""
 	import os
-	import re
 	import subprocess
 
 	cwd = None

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -810,13 +810,13 @@ def _get_icc_profile_path() -> str:
 	if not search_paths:
 		raise RuntimeError("Unable to find /lib path in Ghostscript search paths")
 
-	if search_paths:
-		path = search_paths.group(2).strip()
-		icc_path = os.path.join(path[:-4], "iccprofiles")
-		if os.path.exists(icc_path):
-			return icc_path
+	path = search_paths.group(2).strip()
+	icc_path = os.path.join(path[:-4], "iccprofiles")
 
-	raise RuntimeError("Unable to find ICC profiles folder in Ghostscript search paths.")
+	if not os.path.exists(icc_path):
+		raise RuntimeError("Unable to find ICC profiles folder in Ghostscript search paths.")
+
+	return icc_path
 
 
 def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -785,7 +785,7 @@ def download_pdf(
 			frappe.local.response.filecontent = zugferd_pdf
 
 
-def _create_symlink_to_icc_profile():
+def _create_symlink_to_icc_profile() -> None:
 	"""Create a symlink to the ICC profile in the Ghostscript installation."""
 	import os
 	import re
@@ -845,7 +845,7 @@ def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 		return pdfa_data
 
 
-def _is_ghostscript_installed():
+def _is_ghostscript_installed() -> bool:
 	"""Check if Ghostscript is installed on the system."""
 	import shutil
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -785,28 +785,37 @@ def download_pdf(
 			frappe.local.response.filecontent = zugferd_pdf
 
 
-def _create_symlink_to_icc_profile() -> None:
-	"""Create a symlink to the ICC profile in the Ghostscript installation."""
+def _get_icc_profile_path() -> str:
+	"""Get the path to the ICC profile used by Ghostscript."""
 	import os
 	import re
 	import subprocess
 
 	gs_output = subprocess.run(["gs", "-h"], capture_output=True, text=True)
-	search_paths = re.findall(r"Search path:\n([0-9a-zA-Z\/ :.\n]+)Ghostscript", gs_output.stdout, re.DOTALL)
-	search_paths = search_paths[0].replace("\n", "").strip()
-	lib_path = None
-	paths = search_paths.split(":")
-	for path in paths:
-		if path.strip().endswith("/lib"):
-			lib_path = path.strip()[:-4]
-			break
-	if lib_path:
-		icc_path = os.path.join(lib_path, "iccprofiles/srgb.icc")
-		if os.path.isfile(icc_path):
-			os.symlink(icc_path, "srgb.icc")
-			return
+	# the output of `gs -h` contains the search paths for Ghostscript
+	# it looks like the following:
+	# ...
+	# Search path:
+	#   /usr/share/ghostscript/9.55.0/Resource/Init :
+	#   /usr/share/ghostscript/9.55.0/lib :
+	#   /usr/share/ghostscript/9.55.0/Resource/Font :
+	#   /usr/share/ghostscript/fonts : /var/lib/ghostscript/fonts :
+	#   /usr/share/cups/fonts : /usr/share/ghostscript/fonts :
+	#   /usr/local/lib/ghostscript/fonts : /usr/share/fonts
+	# Ghostscript is also using fontconfig to search for font files
+	# ...
+	search_paths = re.search(r"Search path:\n(.*?)Ghostscript", gs_output.stdout, re.DOTALL)
+	if not search_paths:
+		raise RuntimeError("Unable to find Ghostscript search paths")
 
-	raise RuntimeError("Unable to find ICC profile in Ghostscript search paths")
+	for path in search_paths.group(1).split(":"):
+		path = path.strip()
+		if path.endswith("/lib"):
+			icc_path = os.path.join(path[:-4], "iccprofiles")
+			if os.path.exists(icc_path):
+				return icc_path
+
+	raise RuntimeError("Unable to find ICC profiles folder in Ghostscript search paths.")
 
 
 def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
@@ -815,10 +824,11 @@ def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 	import re
 	import subprocess
 
+	cwd = None
 	if not os.path.isfile("srgb.icc"):
 		# the PDFA_def.ps file requires the srgb.icc file to be present in the current directory
-		# if it is not present, we create a symlink to the srgb.icc file in the Ghostscript installation
-		_create_symlink_to_icc_profile()
+		# if it is not present, change the current working directory to the Ghostscript installation
+		cwd = _get_icc_profile_path()
 
 	with subprocess.Popen(
 		[
@@ -835,6 +845,7 @@ def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 			"PDFA_def.ps",
 			"-",
 		],
+		cwd=cwd,
 		stdin=subprocess.PIPE,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.PIPE,

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -875,7 +875,10 @@ def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 	from drafthorse.pdf import attach_xml
 
 	if _is_ghostscript_installed():
-		pdf_data = _convert_pdf_to_pdfa(pdf_data)
+		try:
+			pdf_data = _convert_pdf_to_pdfa(pdf_data)
+		except RuntimeError:
+			frappe.log_error("Error converting PDF to PDF/A-3 using Ghostscript.")
 
 	level = frappe.db.get_value("Sales Invoice", invoice_id, "einvoice_profile")
 	if level == "XRECHNUNG":

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -839,7 +839,7 @@ def _convert_pdf_to_pdfa(pdf_data: bytes) -> bytes:
 			"-dPDFA=3",
 			"-dBATCH",
 			"-dNOPAUSE",
-			"-dPDFACompatibilityPolicy=1",
+			"-dPDFACompatibilityPolicy=2",
 			"-sColorConversionStrategy=RGB",
 			"--permit-file-read=srgb.icc",
 			"-sDEVICE=pdfwrite",


### PR DESCRIPTION
Convert PDF to PDF/A-3 if ghostscript is installed.
Fail on error and do not output pdf/a-3 data with xml data, erpnext will output the default pdf.

The switch `"-dPDFACompatibilityPolicy=1",` will behave like
```

PDFACompatibilityPolicy integer

    When an operation (e.g. pdfmark) is encountered which cannot be emitted in a PDF/A compliant file, this policy is consulted, there are currently three possible values:

    0 - (default) Include the feature or operation in the output file, the file will not be PDF/A compliant. Because the document Catalog is emitted before this is encountered, the file will still contain PDF/A metadata but will not be compliant. A warning will be emitted in this case.

    1 - The feature or operation is ignored, the resulting PDF file will be PDF/A compliant. A warning will be emitted for every elided feature.

    2 - Processing of the file is aborted with an error, the exact error may vary depending on the nature of the PDF/A incompatibility.

```

Maybe change it later to 2 or make it configurable.