### PR TITLE
fix: ensure vatex reason code is in upper case

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -384,7 +384,7 @@ class EInvoiceGenerator:
 					("Tax Category", self.invoice.tax_category),
 					("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 				]
-			)
+			).upper()
 
 		li.settlement.monetary_summation.total_amount = item.amount
 		self.doc.trade.items.add(li)
@@ -515,7 +515,7 @@ class EInvoiceGenerator:
 				("Tax Category", self.invoice.tax_category),
 				("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 			]
-		)
+		).upper()
 		self.doc.trade.settlement.trade_tax.add(trade_tax)
 
 	def _add_payment_terms(self):


### PR DESCRIPTION
The code list specifies the codes in lowercase, but some of the schematron files check for uppercase codes only. To ensure successful validation, we uppercase all VAT exemption reason codes.
