### PR TITLE
feat(Sales Invoice): allow empty profile, fetch default from Customer master

### DIFF
--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -2,6 +2,16 @@ from .utils import identity as _
 
 
 def get_custom_fields():
+	PROFILE_OPTIONS = "\n".join(
+		[
+			"",
+			"BASIC",
+			"EN 16931",
+			"EXTENDED",
+			"XRECHNUNG",
+		]
+	)
+
 	return {
 		"Purchase Invoice": [
 			{
@@ -52,15 +62,7 @@ def get_custom_fields():
 				"label": _("E Invoice Profile"),
 				"insert_after": "e_invoice_validation_section",
 				"fieldtype": "Select",
-				"options": "\n".join(
-					[
-						"BASIC",
-						"EN 16931",
-						"EXTENDED",
-						"XRECHNUNG",
-					]
-				),
-				"default": "EXTENDED",
+				"options": PROFILE_OPTIONS,
 				"print_hide": 1,
 			},
 			{
@@ -70,6 +72,7 @@ def get_custom_fields():
 				"fieldtype": "Check",
 				"read_only": 1,
 				"print_hide": 1,
+				"depends_on": "eval:!!doc.einvoice_profile",
 			},
 			{
 				"fieldname": "validation_errors",
@@ -78,7 +81,7 @@ def get_custom_fields():
 				"fieldtype": "Text",
 				"read_only": 1,
 				"print_hide": 1,
-				"depends_on": "eval:!doc.einvoice_is_correct",
+				"depends_on": "eval:doc.einvoice_profile && !doc.einvoice_is_correct",
 			},
 		],
 	}

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -30,6 +30,14 @@ def get_custom_fields():
 				"insert_after": "language",
 				"fieldtype": "Data",
 			},
+			{
+				"fieldname": "einvoice_profile",
+				"label": _("E Invoice Profile"),
+				"insert_after": "buyer_reference",
+				"fieldtype": "Select",
+				"options": PROFILE_OPTIONS,
+				"default": "EXTENDED",
+			},
 		],
 		"Sales Order": [
 			{
@@ -63,6 +71,8 @@ def get_custom_fields():
 				"insert_after": "e_invoice_validation_section",
 				"fieldtype": "Select",
 				"options": PROFILE_OPTIONS,
+				"fetch_from": "customer.einvoice_profile",
+				"fetch_if_empty": 1,
 				"print_hide": 1,
 			},
 			{

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.js
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.js
@@ -2,13 +2,17 @@ frappe.ui.form.on("Sales Invoice", {
 	refresh: function (frm) {
 		frm.trigger("add_einvoice_button");
 
-		if (!frm.is_dirty() && !frm.doc.einvoice_is_correct) {
+		if (!frm.is_dirty() && !frm.doc.einvoice_is_correct && frm.doc.einvoice_profile) {
 			frm.dashboard.set_headline_alert(
 				__("Please note the validation errors of the e-invoice.")
 			);
 		}
 	},
 	add_einvoice_button: function (frm) {
+		if (frm.is_new() || !frm.doc.einvoice_profile) {
+			return;
+		}
+
 		frm.page.add_menu_item(__("Download eInvoice"), () => {
 			window.open(
 				`/api/method/eu_einvoice.european_e_invoice.custom.sales_invoice.download_xrechnung?invoice_id=${encodeURIComponent(

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -703,6 +703,9 @@ def validate_einvoice(doc: SalesInvoice):
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
 
+	if not doc.einvoice_profile:
+		return
+
 	try:
 		xml_string = get_einvoice(doc).decode()
 	except Exception:
@@ -900,7 +903,7 @@ def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 			frappe.log_error("Error converting PDF to PDF/A-3 using Ghostscript.")
 
 	level = frappe.db.get_value("Sales Invoice", invoice_id, "einvoice_profile")
-	if level == "XRECHNUNG":
+	if not level or level == "XRECHNUNG":
 		# XRECHNUNG does not support embedding into PDF
 		return pdf_data
 

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,6 +4,6 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 8
+execute:from eu_einvoice.install import after_install; after_install() # 10
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import


### PR DESCRIPTION
- Allow empty _E Invoice Profile_ in **Sales Invoice** to be empty. This disables creation and validation of the e-invoice.
- Allow setting a default e-invoice profile per **Customer** (_empty_ is also possible here)
