### PR TITLE
feat: bump drafthorse to 2025.1.0

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -259,9 +259,7 @@ class EInvoiceGenerator:
 			electronic_address = self.company.email
 
 		if electronic_address:
-			self.doc.trade.agreement.seller.electronic_address.add(
-				URIUniversalCommunication(uri_ID=("EM", electronic_address))
-			)
+			self.doc.trade.agreement.seller.electronic_address.uri_ID = ("EM", electronic_address)
 
 	def _set_seller_contact(self):
 		seller_contact_phone = self.company.phone_no
@@ -293,9 +291,7 @@ class EInvoiceGenerator:
 			self._set_buyer_contact()
 
 		if self.invoice.contact_email:
-			self.doc.trade.agreement.buyer.electronic_address.add(
-				URIUniversalCommunication(uri_ID=("EM", self.invoice.contact_email))
-			)
+			self.doc.trade.agreement.buyer.electronic_address.uri_ID = ("EM", self.invoice.contact_email)
 
 		self._set_buyer_tax_id()
 

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -136,7 +136,7 @@ class EInvoiceImport(Document):
 	def read_values_from_einvoice(self) -> None:
 		xml_bytes = self.get_xml_bytes()
 		try:
-			doc = DrafthorseDocument.parse(xml_bytes)
+			doc = DrafthorseDocument.parse(xml_bytes, strict=False)
 		except XMLSyntaxError:
 			frappe.throw(_("The uploaded file does not contain valid XML data."))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "factur-x~=3.1",
-    "drafthorse~=2.4.0",
+    "drafthorse~=2025.1.0",
     "saxonche~=12.5.0",
     "lxml>=4.9.3,<6.0.0",
 ]


### PR DESCRIPTION
- Bump drafthorse to version `2025.1.0`. Supports lax parsing mode and additional elements.
- **E Invoice Import**: use lax parsing mode. This means that parsing invoices with unknown elements will no longer fail.
- Fixed cardinality of electronic address, as enforced by new drafthorse version.
