### PR TITLE
fix: XRechnung has to be "compliant" to EN 16931, i.e. not contain additional elements

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -706,7 +706,10 @@ def validate_einvoice(doc: SalesInvoice):
 		return
 
 	try:
-		validation_errors = get_validation_errors(xml_string, EInvoiceProfile(doc.einvoice_profile))
+		invoice_profile = EInvoiceProfile(doc.einvoice_profile)
+		validation_errors = get_validation_errors(xml_string, invoice_profile)
+		if invoice_profile == EInvoiceProfile.XRECHNUNG:
+			validation_errors += get_validation_errors(xml_string, EInvoiceProfile.EN16931)
 	except Exception:
 		doc.validation_errors = _("Cannot validate E Invoice schematron.")
 		return

--- a/eu_einvoice/utils.py
+++ b/eu_einvoice/utils.py
@@ -29,16 +29,16 @@ class EInvoiceProfile(Enum):
 PROFILE_TO_SCHEMA = {
 	EInvoiceProfile.BASIC: "FACTUR-X_BASIC",
 	EInvoiceProfile.EN16931: "FACTUR-X_EN16931",
+	EInvoiceProfile.XRECHNUNG: "FACTUR-X_EN16931",
 	EInvoiceProfile.EXTENDED: "FACTUR-X_EXTENDED",
-	EInvoiceProfile.XRECHNUNG: "FACTUR-X_EXTENDED",  # TODO: https://github.com/pretix/python-drafthorse/issues/54
 }
 
 # Map of EInvoiceProfile to GuidelineSpecifiedDocumentContextParameter
 PROFILE_TO_GUIDELINE = {
 	EInvoiceProfile.BASIC: "urn:cen.eu:en16931:2017#compliant#urn:factur-x.eu:1p0:basic",
 	EInvoiceProfile.EN16931: "urn:cen.eu:en16931:2017",
-	EInvoiceProfile.EXTENDED: "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
 	EInvoiceProfile.XRECHNUNG: "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0",
+	EInvoiceProfile.EXTENDED: "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
 }
 GUIDELINE_TO_PROFILE = {v: k for k, v in PROFILE_TO_GUIDELINE.items()}
 

--- a/eu_einvoice/utils.py
+++ b/eu_einvoice/utils.py
@@ -19,8 +19,8 @@ class EInvoiceProfile(Enum):
 		order = [
 			EInvoiceProfile.BASIC,
 			EInvoiceProfile.EN16931,
-			EInvoiceProfile.EXTENDED,
 			EInvoiceProfile.XRECHNUNG,
+			EInvoiceProfile.EXTENDED,
 		]
 		return order.index(self) < order.index(other)
 


### PR DESCRIPTION
XRechnung has to be "compliant" to EN 16931, i.e. not contain additional elements. This is different from "conformant", where additional elements would be allowed.

Before this PR, XRechnung was constructed as "conformant", so that it would also contain the additional elements of the ZUGFeRD EXTENDED profile. Now the construction and validation will produce a "compliant" XRechnung.
