### PR TITLE
feat: show validation warnings

### DIFF
--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -99,5 +99,14 @@ def get_custom_fields():
 				"print_hide": 1,
 				"depends_on": "eval:doc.einvoice_profile && !doc.einvoice_is_correct",
 			},
+			{
+				"fieldname": "validation_warnings",
+				"label": _("Validation Warnings"),
+				"insert_after": "validation_errors",
+				"fieldtype": "Text",
+				"read_only": 1,
+				"print_hide": 1,
+				"depends_on": "eval:doc.einvoice_profile && doc.validation_warnings",
+			},
 		],
 	}

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -708,6 +708,7 @@ def validate_doc(doc, event):
 def validate_einvoice(doc: SalesInvoice):
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
+	doc.validation_warnings = ""
 
 	if not doc.einvoice_profile:
 		return
@@ -720,9 +721,11 @@ def validate_einvoice(doc: SalesInvoice):
 
 	try:
 		invoice_profile = EInvoiceProfile(doc.einvoice_profile)
-		validation_errors = get_validation_errors(xml_string, invoice_profile)
+		validation_errors, warnings = get_validation_errors(xml_string, invoice_profile)
+
 		if invoice_profile == EInvoiceProfile.XRECHNUNG:
-			validation_errors += get_validation_errors(xml_string, EInvoiceProfile.EN16931)
+			basic_errors, basic_warnings = get_validation_errors(xml_string, EInvoiceProfile.EN16931)
+			validation_errors += basic_errors
 	except Exception:
 		doc.validation_errors = _("Cannot validate E Invoice schematron.")
 		return
@@ -731,6 +734,9 @@ def validate_einvoice(doc: SalesInvoice):
 		doc.validation_errors += "\n".join(validation_errors)
 	else:
 		doc.einvoice_is_correct = 1
+
+	if any(warnings):
+		doc.validation_warnings += "\n".join(warnings)
 
 
 def get_item_rate(item_tax_template: str | None, taxes: list[dict]) -> float | None:

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -13,6 +13,7 @@
   "e_invoice_is_correct",
   "validation_details_section",
   "validation_errors",
+  "validation_warnings",
   "header_section",
   "issue_date",
   "id",
@@ -459,6 +460,13 @@
    "label": "Charge Total",
    "options": "currency",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.validation_warnings",
+   "fieldname": "validation_warnings",
+   "fieldtype": "Text",
+   "label": "Validation Warnings",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -469,7 +477,7 @@
    "link_fieldname": "e_invoice_import"
   }
  ],
- "modified": "2025-02-24 05:53:50.848425",
+ "modified": "2025-05-07 00:53:28.840615",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Import",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -86,6 +86,7 @@ class EInvoiceImport(Document):
 		taxes: DF.Table[EInvoiceTradeTax]
 		total_prepaid: DF.Currency
 		validation_errors: DF.Text | None
+		validation_warnings: DF.Text | None
 	# end: auto-generated types
 
 	def validate(self):
@@ -189,10 +190,13 @@ class EInvoiceImport(Document):
 
 	def _validate_schematron(self, xml_bytes):
 		self.validation_errors = ""
+		self.validation_warnings = ""
 		xml_string = xml_bytes.decode("utf-8")
 
 		try:
-			validation_errors = get_validation_errors(xml_string, EInvoiceProfile(self.profile))
+			validation_errors, validation_warnings = get_validation_errors(
+				xml_string, EInvoiceProfile(self.profile)
+			)
 		except Exception:
 			frappe.log_error(
 				title="E Invoice schematron validation",
@@ -211,6 +215,9 @@ class EInvoiceImport(Document):
 			self.validation_errors += "\n".join(validation_errors)
 		else:
 			self.e_invoice_is_correct = 1
+
+		if any(validation_warnings):
+			self.validation_warnings += "\n".join(validation_warnings)
 
 	def parse_seller(self, seller: "TradeParty"):
 		self.seller_name = str(seller.name)

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,6 +4,6 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 11
+execute:from eu_einvoice.install import after_install; after_install() # 13
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import

--- a/eu_einvoice/schematron/__init__.py
+++ b/eu_einvoice/schematron/__init__.py
@@ -23,13 +23,19 @@ def get_errors_from_stylesheet(xml_string: str, stylesheet: str) -> list[str]:
 	return extract_failed_asserts(report)
 
 
-def extract_failed_asserts(xml: bytes) -> list[str]:
+def extract_failed_asserts(xml: bytes) -> tuple[list[str], list[str]]:
 	root = objectify.fromstring(xml)
 	failed_asserts = root.xpath(
 		"//svrl:failed-assert/svrl:text",
 		namespaces={"svrl": "http://purl.oclc.org/dsdl/svrl"},
 	)
-	return [failed_assert.text.strip() for failed_assert in failed_asserts if failed_assert.text]
+	warnings = root.xpath(
+		"//svrl:successful-report/svrl:text",
+		namespaces={"svrl": "http://purl.oclc.org/dsdl/svrl"},
+	)
+	errors = [failed_assert.text.strip() for failed_assert in failed_asserts if failed_assert.text]
+	warnings = [warning.text.strip() for warning in warnings if warning.text]
+	return errors, warnings
 
 
 def get_validation_report(xml_string: str, stylesheet_file: str) -> bytes:


### PR DESCRIPTION
Until now, we showed only validation errors. Now we show warnings as well. Applies to both **Sales Invoice** and **E Invoice Import**.

### E Invoice Import

![import](https://github.com/user-attachments/assets/6e9c6b37-cfd1-45c3-8cc9-8a4728aaa73a)

### Sales Invoice

![si](https://github.com/user-attachments/assets/051974fb-13c8-4882-9599-31d115011406)
