### PR TITLE
fix(Sales Invoice): remove tax total without currency

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -617,7 +617,6 @@ class EInvoiceGenerator:
 		self.doc.trade.settlement.monetary_summation.tax_basis_total = (
 			self.invoice.net_total + actual_charge_total
 		)
-		self.doc.trade.settlement.monetary_summation.tax_total = tax_total
 		self.doc.trade.settlement.monetary_summation.tax_total_other_currency.add(
 			(tax_total, self.invoice.currency)
 		)


### PR DESCRIPTION
Schematron rules for the BASIC and EXTENDED profiles require a tax total with currency and fire a warning if there are two tax totals, one with currency and one without:

> Element variant 'ram:TaxTotalAmount[ not(@currencyID=../../ram:InvoiceCurrencyCode) and not(@currencyID=../../ram:TaxCurrencyCode)]' is marked as not used in the given context.

With this PR we no longer add the tax total without currency to future e-invoices.

