### PR TITLE
feat(E Invoice Import): create Purchase Invoice from error message

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
 	},
 	"root": true,
 	"globals": {
+		"eu_einvoice": true,
 		"frappe": true,
 		"Vue": true,
 		"SetVueGlobals": true,

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -21,7 +21,14 @@ def get_custom_fields():
 				"fieldtype": "Link",
 				"options": "E Invoice Import",
 				"read_only": 1,
-			}
+				"depends_on": "eval:doc.e_invoice_import",
+			},
+			{
+				"fieldname": "supplier_invoice_file",
+				"label": _("Supplier Invoice File"),
+				"insert_after": "bill_date",
+				"fieldtype": "Attach",
+			},
 		],
 		"Customer": [
 			{

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -146,7 +146,7 @@ class EInvoiceImport(Document):
 		self.set_onload("unlinked_invoice", unlinked_invoice)
 
 	def get_xml_bytes(self) -> bytes:
-		return get_xml_bytes(Path(get_site_path(self.einvoice.lstrip("/"))).resolve())
+		return get_xml_bytes(self.einvoice)
 
 	def read_values_from_einvoice(self) -> None:
 		xml_bytes = self.get_xml_bytes()
@@ -414,18 +414,32 @@ def flt_or_none(value) -> float | None:
 	return float(value) if value is not None else None
 
 
-def get_xml_bytes(file: Path) -> bytes:
-	"""Reads the XML data from the given XML or PDF file path."""
+def get_xml_bytes(einvoice: str) -> bytes:
+	"""Reads the XML data from the attached XML or PDF file."""
+	CREATE_PI_ACTION = {
+		"label": _("Create Purchase Invoice"),
+		"client_action": "eu_einvoice.utils.new_purchase_invoice",
+	}
+
+	file = relative_url_to_path(einvoice)
 	if file.suffix.lower() == ".pdf":
 		xml_filename, xml_bytes = get_xml_from_pdf(file.read_bytes(), check_xsd=False)
 		if not xml_bytes:
-			frappe.throw(_("No XML data found in PDF file."))
+			frappe.throw(
+				_("No XML data found in PDF file."),
+				primary_action=CREATE_PI_ACTION,
+			)
 	elif file.suffix.lower() == ".xml":
 		xml_bytes = file.read_bytes()
 	else:
-		frappe.throw(_("Unsupported file format '{0}'").format(file.suffix))
+		frappe.throw(_("Unsupported file format '{0}'").format(file.suffix), primary_action=CREATE_PI_ACTION)
 
 	return xml_bytes
+
+
+def relative_url_to_path(url: str) -> Path:
+	"""Convert a relative URL to a file path."""
+	return Path(get_site_path(url.lstrip("/"))).resolve()
 
 
 @frappe.whitelist()

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -426,13 +426,22 @@ def get_xml_bytes(einvoice: str) -> bytes:
 		xml_filename, xml_bytes = get_xml_from_pdf(file.read_bytes(), check_xsd=False)
 		if not xml_bytes:
 			frappe.throw(
-				_("No XML data found in PDF file."),
+				msg=_(
+					"No machine-readable data was found in the PDF file. You can create a regular Purchase Invoice manually instead."
+				),
+				title=_("Not an E-Invoice"),
 				primary_action=CREATE_PI_ACTION,
 			)
 	elif file.suffix.lower() == ".xml":
 		xml_bytes = file.read_bytes()
 	else:
-		frappe.throw(_("Unsupported file format '{0}'").format(file.suffix), primary_action=CREATE_PI_ACTION)
+		frappe.throw(
+			msg=_(
+				"The format of the uploaded file ({0}) is not supported for E-Invoices. Please upload a valid E-Invoice file or create a regular Purchase Invoice manually instead."
+			).format(file.suffix),
+			title=_("Unsupported file format"),
+			primary_action=CREATE_PI_ACTION,
+		)
 
 	return xml_bytes
 

--- a/eu_einvoice/hooks.py
+++ b/eu_einvoice/hooks.py
@@ -26,7 +26,7 @@ required_apps = ["frappe/erpnext"]
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/eu_einvoice/css/eu_einvoice.css"
-# app_include_js = "/assets/eu_einvoice/js/eu_einvoice.js"
+app_include_js = "/assets/eu_einvoice/js/utils.js"
 
 # include js, css files in header of web template
 # web_include_css = "/assets/eu_einvoice/css/eu_einvoice.css"

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,6 +4,6 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 13
+execute:from eu_einvoice.install import after_install; after_install() # 14
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import

--- a/eu_einvoice/public/js/utils.js
+++ b/eu_einvoice/public/js/utils.js
@@ -1,0 +1,17 @@
+frappe.provide("eu_einvoice");
+
+eu_einvoice.utils = {
+	/**
+	 * Supposed to be called when the user clicks the "Create Purchase Invoice"
+	 * button in the error message, when the uploaded file in the E Invoice Import
+	 * does not contain XML data.
+	 *
+	 * Needs to be a global function because it is called 'from the backend'.
+	 */
+	new_purchase_invoice: function () {
+		frappe.new_doc("Purchase Invoice", {
+			company: cur_frm.doc.company,
+			supplier_invoice_file: cur_frm.doc.einvoice,
+		});
+	},
+};


### PR DESCRIPTION
If the uploaded file is a PDF and does not contain XML data, or if the file type is unsupported, we show an error message. This error message now contains a button "Create Purchase Invoice", which redirects to a new **Purchase Invoice** form that has the uploaded file attached.

https://github.com/user-attachments/assets/eeb1059a-b1b8-47b2-a4d1-7378656e9d2e

Resolves #117