### PR TITLE
fix: Handle more than 140 chars in product_name

### DIFF
--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -246,8 +246,14 @@ class EInvoiceImport(Document):
 		basis_qty = float(li.agreement.net.basis_quantity._amount or "1")
 		rate = net_rate / basis_qty
 
-		item.product_name = str(li.product.name)
-		item.product_description = str(li.product.description)
+		product_name_full = str(li.product.name)
+		product_description = str(li.product.description)
+		if len(product_name_full) > 140:
+			item.product_name = product_name_full[:140]
+			item.product_description = product_name_full + " | " + product_description
+		else:
+			item.product_name = product_name_full
+			item.product_description = product_description
 		item.seller_product_id = str(li.product.seller_assigned_id)
 		item_code = str(li.product.buyer_assigned_id)
 		if item_code and not frappe.db.exists("Item", item_code):

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
@@ -33,7 +33,7 @@
   },
   {
    "fieldname": "product_name",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Product Name",
    "read_only": 1

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
@@ -33,7 +33,7 @@
   },
   {
    "fieldname": "product_name",
-   "fieldtype": "Small Text",
+   "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Product Name",
    "read_only": 1


### PR DESCRIPTION
Mit dieser Änderung können Eingangsrechnungen bearbeitet werden, bei denen der Produktname mehr als 140 Zeichen beträgt (Was akut vorgekommen ist). Der Standard Docfield Typ "Data" erlaubt maximal 140 Zeichen.

Zunächst wurde überlegt den Datentyp auf "Small Text" zu ändern, dies kann aber später im ERPNext System bei Item zu Problemen führen. Als Lösungsvorschlag wurde folgendes implementiert:

- Der Produktname wird auf max 140 Zeichen gesetzt
- Sofern der Produktname der Rechnung länger ist, wird er im product_name gekürzt und vor die Beschreibung angehangen mit einem Trennzeichen