### PR TITLE
feat: support attached files (IBT-72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ The following fields of the **Sales Invoice** are currently considered for the e
 - Grand Total
 - Total Advance
 - Outstanding Amount
+- Embedded Document
+    This attachment field can be used to embed an additional supporting document into the e-invoice (XML-)file. For example, a time report in PDF format.
 
 [1] The correct taxable amount is only available starting from ERPNext v16. For earlier versions we currently have to approximate it, which comes with a small error margin.
 

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -94,6 +94,7 @@ def get_custom_fields():
 				"insert_after": "einvoice_profile",
 				"fieldtype": "Attach",
 				"depends_on": "einvoice_profile",
+				"description": _("Additional supporting document to be embedded in the e-invoice file."),
 			},
 			{
 				"fieldname": "einvoice_is_correct",

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -89,6 +89,13 @@ def get_custom_fields():
 				"print_hide": 1,
 			},
 			{
+				"fieldname": "einvoice_embedded_document",
+				"label": _("Embedded Document"),
+				"insert_after": "einvoice_profile",
+				"fieldtype": "Attach",
+				"depends_on": "einvoice_profile",
+			},
+			{
 				"fieldname": "einvoice_is_correct",
 				"label": _("E Invoice Is Correct"),
 				"insert_after": "e_invoice_validation_section",

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -180,10 +180,20 @@ class EInvoiceGenerator:
 		if not self.invoice.einvoice_embedded_document:
 			return
 
-		file_id, (mime_type, file_name, content) = get_attached_file(self.invoice.einvoice_embedded_document)
+		file = find_file_by_url(self.invoice.einvoice_embedded_document)
+
+		content = None
+		if not file.is_remote_file:
+			file_name = os.path.basename(file.file_url)
+			mime_type = mimetypes.guess_type(file.file_url)[0]
+			content = as_base_64(file.get_content())
+
 		ref_doc = AdditionalReferencedDocument()
-		ref_doc.issuer_assigned_id = file_id
-		ref_doc.attached_object = (mime_type, file_name, content)
+		ref_doc.issuer_assigned_id = file.name
+		if file.is_remote_file:
+			ref_doc.uri_id = file.file_url
+		else:
+			ref_doc.attached_object = (mime_type, file_name, content)
 		ref_doc.type_code = "916"  # "Related document" according to UNTDID 1001
 		self.doc.trade.agreement.additional_references.add(ref_doc)
 
@@ -831,19 +841,12 @@ def get_bank_details(mode_of_payment: str, company: str) -> tuple[str | None, st
 	return (iban, bic or None)
 
 
-def get_attached_file(file_url: str) -> tuple[str, tuple[str, str, str]]:
-	"""Get the attached file from the file URL.
-
-	Returns a tuple of the file name and a tuple of the mime type, file name, and base64-encoded content.
-	"""
-	file = find_file_by_url(file_url)
-	content = file.get_content()
-	file_name = os.path.basename(file_url)
-	mime_type = mimetypes.guess_type(file_url)[0]
+def as_base_64(content: str | bytes) -> str:
+	"""Convert a string or bytes object to a base64-encoded string."""
 	if isinstance(content, str):
 		content = content.encode("utf-8")
 
-	return file.name, (mime_type, file_name, b64encode(content).decode("utf-8"))
+	return b64encode(content).decode("utf-8")
 
 
 @frappe.whitelist(allow_guest=True)

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import mimetypes
+import os
 import re
+from base64 import b64encode
 from typing import TYPE_CHECKING
 
 import frappe
@@ -8,9 +11,11 @@ from drafthorse.models.accounting import ApplicableTradeTax, AppliedTradeTax
 from drafthorse.models.document import Document, IncludedNote
 from drafthorse.models.party import TaxRegistration, URIUniversalCommunication
 from drafthorse.models.payment import PaymentTerms
+from drafthorse.models.references import AdditionalReferencedDocument
 from drafthorse.models.trade import LogisticsServiceCharge
 from drafthorse.models.tradelines import LineItem
 from frappe import _
+from frappe.core.doctype.file.utils import find_file_by_url
 from frappe.core.utils import html2text
 from frappe.utils.data import date_diff, flt, getdate, to_markdown
 
@@ -136,6 +141,9 @@ class EInvoiceGenerator:
 			if self.invoice.po_date and self.profile >= EInvoiceProfile.EXTENDED:
 				self.doc.trade.agreement.buyer_order.issue_date_time = getdate(self.invoice.po_date)
 
+		if self.profile >= EInvoiceProfile.EN16931:
+			self._embed_attachment()
+
 		sales_orders = set()
 		for item in self.invoice.items:
 			if item.sales_order:
@@ -166,6 +174,18 @@ class EInvoiceGenerator:
 		self._add_delivery_date()
 		self._add_payment_terms()
 		self._set_totals()
+
+	def _embed_attachment(self):
+		"""Add the embedded document to the einvoice."""
+		if not self.invoice.einvoice_embedded_document:
+			return
+
+		file_id, (mime_type, file_name, content) = get_attached_file(self.invoice.einvoice_embedded_document)
+		ref_doc = AdditionalReferencedDocument()
+		ref_doc.issuer_assigned_id = file_id
+		ref_doc.attached_object = (mime_type, file_name, content)
+		ref_doc.type_code = "916"  # "Related document" according to UNTDID 1001
+		self.doc.trade.agreement.additional_references.add(ref_doc)
 
 	def _set_context(self):
 		"""Set default context according to XRechnung 3.0.2"""
@@ -809,6 +829,21 @@ def get_bank_details(mode_of_payment: str, company: str) -> tuple[str | None, st
 
 	bic = frappe.db.get_value("Bank", bank, "swift_number") if bank else None
 	return (iban, bic or None)
+
+
+def get_attached_file(file_url: str) -> tuple[str, tuple[str, str, str]]:
+	"""Get the attached file from the file URL.
+
+	Returns a tuple of the file name and a tuple of the mime type, file name, and base64-encoded content.
+	"""
+	file = find_file_by_url(file_url)
+	content = file.get_content()
+	file_name = os.path.basename(file_url)
+	mime_type = mimetypes.guess_type(file_url)[0]
+	if isinstance(content, str):
+		content = content.encode("utf-8")
+
+	return file.name, (mime_type, file_name, b64encode(content).decode("utf-8"))
 
 
 @frappe.whitelist(allow_guest=True)

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-02-24 12:02+0053\n"
+"POT-Creation-Date: 2025-08-26 12:21+0053\n"
 "PO-Revision-Date: 2024-11-25 18:57+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -16,9 +16,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:687
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:732
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht unterstützt."
 
@@ -32,6 +32,10 @@ msgstr ""
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
 msgstr "Tatsächlicher Betrag"
+
+#: eu_einvoice/custom_fields.py:97
+msgid "Additional supporting document to be embedded in the e-invoice file."
+msgstr "Zusätzliches Dokument, das in die E-Rechnung eingebettet werden soll."
 
 #. Label of the agreement_tab (Tab Break) field in DocType 'E Invoice Import'
 #. Label of the agreement_section (Section Break) field in DocType 'E Invoice
@@ -51,7 +55,7 @@ msgstr "Abschläge gesamt"
 msgid "Amended From"
 msgstr "Korrektur von"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:100
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:101
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr "Eine E-Rechnung mit der gleichen Rechnungs-ID und Lieferanten existiert bereits."
 
@@ -128,8 +132,8 @@ msgstr "Käufer-Name"
 msgid "Buyer Postcode"
 msgstr "Käufer-Postleitzahl"
 
-#: eu_einvoice/custom_fields.py:29 eu_einvoice/custom_fields.py:45
-#: eu_einvoice/custom_fields.py:55
+#: eu_einvoice/custom_fields.py:36 eu_einvoice/custom_fields.py:52
+#: eu_einvoice/custom_fields.py:62
 msgid "Buyer Reference"
 msgstr "Käufer-Referenz"
 
@@ -145,11 +149,11 @@ msgstr "Berechneter Betrag"
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:705
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:751
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:762
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
@@ -158,12 +162,27 @@ msgstr "E-Rechnung konnte nicht validiert werden."
 msgid "Charge Total"
 msgstr "Zuschläge gesamt"
 
+#. Label of a Link in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Code List"
+msgstr ""
+
+#. Description of a Card Break in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Code Lists are typically public lists of common codes used in data interchange between third parties"
+msgstr "Code-Listen sind in der Regel öffentliche Listen von häufig verwendeten Codes, die in der Datenübertragung zwischen Drittanbietern verwendet werden."
+
+#. Label of a Link in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Common Code"
+msgstr ""
+
 #. Label of the company (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr "Unternehmen"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:203
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:207
 msgid "Could not validate E Invoice schematron. See Error Log for details."
 msgstr "E-Rechnung konnte nicht validiert werden. Details im Fehlerlog."
 
@@ -177,6 +196,7 @@ msgid "Create Item"
 msgstr "Artikel erstellen"
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:93
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:426
 msgid "Create Purchase Invoice"
 msgstr "Eingangsrechnung erstellen"
 
@@ -215,6 +235,11 @@ msgstr "Rabatt"
 msgid "Document"
 msgstr "Dokument"
 
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Documentation"
+msgstr "Dokumentation"
+
 #: eu_einvoice/european_e_invoice/custom/sales_invoice.js:16
 msgid "Download eInvoice"
 msgstr "E-Rechnung herunterladen"
@@ -241,13 +266,13 @@ msgstr "Fälliger Betrag"
 msgid "E Invoice Import"
 msgstr "E-Rechnungs-Import"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:606
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:642
 msgid "E Invoice Import {0} does not exist"
 msgstr "E-Rechnungs-Import {0} existiert nicht"
 
 #. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
 #. Import'
-#: eu_einvoice/custom_fields.py:80
+#: eu_einvoice/custom_fields.py:101
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
 msgstr "E-Rechnung ist korrekt"
@@ -262,7 +287,7 @@ msgstr "E-Rechnungs-Position"
 msgid "E Invoice Payment Term"
 msgstr "E-Rechnungs-Zahlungsbedingung"
 
-#: eu_einvoice/custom_fields.py:35 eu_einvoice/custom_fields.py:70
+#: eu_einvoice/custom_fields.py:42 eu_einvoice/custom_fields.py:83
 msgid "E Invoice Profile"
 msgstr "E-Rechnungs-Profil"
 
@@ -271,14 +296,23 @@ msgstr "E-Rechnungs-Profil"
 msgid "E Invoice Trade Tax"
 msgstr "E-Rechnungs-Steuer"
 
-#: eu_einvoice/custom_fields.py:63
-msgid "E Invoice Validation"
-msgstr "E-Rechnungs-Validierung"
+#: eu_einvoice/custom_fields.py:70
+msgid "E Invoicing"
+msgstr ""
 
 #. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
 msgstr "E-Rechnung"
+
+#. Name of a Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "E-Invoicing"
+msgstr "E-Rechnung"
+
+#: eu_einvoice/custom_fields.py:93
+msgid "Embedded Document"
+msgstr ""
 
 #. Label of the file_section_section (Section Break) field in DocType 'E
 #. Invoice Import'
@@ -343,9 +377,23 @@ msgstr "Gesamtbeträge"
 msgid "Net Rate"
 msgstr "Nettopreis"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:415
-msgid "No XML data found in PDF file."
-msgstr "Keine XML-Daten in der PDF-Datei gefunden."
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "New E Invoice Import"
+msgstr "Neuer E-Rechnungs-Import"
+
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "New Sales Invoice"
+msgstr "Neue Ausgangsrechnung"
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:435
+msgid "No machine-readable data was found in the PDF file. You can create a regular Purchase Invoice manually instead."
+msgstr "In der PDF-Datei wurden keine maschinenlesbaren Daten gefunden. Sie können stattdessen eine reguläre Eingangsrechnung manuell erstellen."
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:438
+msgid "Not an E-Invoice"
+msgstr "Keine E-Rechnung"
 
 #. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
 #. Term'
@@ -364,11 +412,11 @@ msgstr "Zahlungsmittel"
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:114
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:115
 msgid "Please create or select a supplier before submitting"
 msgstr "Bitte vor dem Buchen einen Lieferanten auswählen oder erstellen."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:120
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:121
 msgid "Please map all invoice lines to an item before submitting"
 msgstr "Bitte vor dem Buchen alle Positionen einem Artikel zuordnen."
 
@@ -376,7 +424,7 @@ msgstr "Bitte vor dem Buchen alle Positionen einem Artikel zuordnen."
 msgid "Please note the validation errors of the e-invoice."
 msgstr "Bitte beachten Sie die Validierungsfehler der E-Rechnung."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:117
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:118
 msgid "Please select a company before submitting"
 msgstr "Bitte vor dem Buchen ein Unternehmen auswählen."
 
@@ -402,7 +450,7 @@ msgstr "Produktname"
 msgid "Profile"
 msgstr "Profil"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:600
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:636
 msgid "Purchase Invoice {0} is already linked to E Invoice Import {1}"
 msgstr "Eingangsrechnung {0} ist bereits mit E-Rechnungs-Import {1} verknüpft"
 
@@ -432,7 +480,7 @@ msgstr ""
 msgid "Rate Applicable Percent"
 msgstr "Anwendbarer Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:626
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:662
 msgid "Row {0}"
 msgstr "Zeile {0}"
 
@@ -492,6 +540,11 @@ msgstr "Verkäufer-Steuer-ID"
 msgid "Settlement"
 msgstr "Ausgleich"
 
+#. Label of a Card Break in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Setup"
+msgstr ""
+
 #. Label of the supplier (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
@@ -501,6 +554,10 @@ msgstr "Lieferant"
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
 msgstr "Lieferanten-Adresse"
+
+#: eu_einvoice/custom_fields.py:28
+msgid "Supplier Invoice File"
+msgstr "Lieferantenrechnungsdatei"
 
 #. Name of a role
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -532,7 +589,11 @@ msgstr "Steuer gesamt"
 msgid "Taxes"
 msgstr "Steuern"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:155
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:445
+msgid "The format of the uploaded file ({0}) is not supported for E-Invoices. Please upload a valid E-Invoice file or create a regular Purchase Invoice manually instead."
+msgstr "Das Format der hochgeladenen Datei ({0}) wird für E-Rechnungen nicht unterstützt. Bitte laden Sie eine gültige E-Rechnungsdatei hoch oder erstellen Sie stattdessen eine reguläre Eingangsrechnung manuell."
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:156
 msgid "The uploaded file does not contain valid XML data."
 msgstr "Die hochgeladene Datei enthält keine gültige XML-Daten."
 
@@ -556,9 +617,9 @@ msgstr "Einheit"
 msgid "Unit Code"
 msgstr "Einheits-Code"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:419
-msgid "Unsupported file format '{0}'"
-msgstr "Nicht unterstütztes Dateiformat '{0}'"
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:448
+msgid "Unsupported file format"
+msgstr "Nicht unterstütztes Dateiformat"
 
 #. Description of the 'E-Invoice' (Attach) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -572,28 +633,34 @@ msgid "Validation Details"
 msgstr "Validierungsdetails"
 
 #. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
-#: eu_einvoice/custom_fields.py:89
+#: eu_einvoice/custom_fields.py:110
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
 msgstr "Validierungsfehler"
+
+#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
+#: eu_einvoice/custom_fields.py:119
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+msgid "Validation Warnings"
+msgstr "Validierungswarnungen"
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:75
 msgid "View {0}"
 msgstr "{0} ansehen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:666
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:655
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:700
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr "Die Gebührenart 'Tatsächlich' wird nur in den E-Rechnungs-Profilen 'EXTENDED' und 'XRECHNUNG' unterstützt."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:643
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:688
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:678
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:723
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,16 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-02-24 12:02+0053\n"
-"PO-Revision-Date: 2025-02-24 12:02+0053\n"
+"POT-Creation-Date: 2025-08-26 12:21+0053\n"
+"PO-Revision-Date: 2025-08-26 12:21+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:687
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:732
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr ""
 
@@ -29,6 +29,10 @@ msgstr ""
 #. Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
+msgstr ""
+
+#: eu_einvoice/custom_fields.py:97
+msgid "Additional supporting document to be embedded in the e-invoice file."
 msgstr ""
 
 #. Label of the agreement_tab (Tab Break) field in DocType 'E Invoice Import'
@@ -49,7 +53,7 @@ msgstr ""
 msgid "Amended From"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:100
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:101
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr ""
 
@@ -126,8 +130,8 @@ msgstr ""
 msgid "Buyer Postcode"
 msgstr ""
 
-#: eu_einvoice/custom_fields.py:29 eu_einvoice/custom_fields.py:45
-#: eu_einvoice/custom_fields.py:55
+#: eu_einvoice/custom_fields.py:36 eu_einvoice/custom_fields.py:52
+#: eu_einvoice/custom_fields.py:62
 msgid "Buyer Reference"
 msgstr ""
 
@@ -143,11 +147,11 @@ msgstr ""
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:705
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:751
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:762
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
@@ -156,12 +160,27 @@ msgstr ""
 msgid "Charge Total"
 msgstr ""
 
+#. Label of a Link in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Code List"
+msgstr ""
+
+#. Description of a Card Break in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Code Lists are typically public lists of common codes used in data interchange between third parties"
+msgstr ""
+
+#. Label of a Link in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Common Code"
+msgstr ""
+
 #. Label of the company (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:203
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:207
 msgid "Could not validate E Invoice schematron. See Error Log for details."
 msgstr ""
 
@@ -175,6 +194,7 @@ msgid "Create Item"
 msgstr ""
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:93
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:426
 msgid "Create Purchase Invoice"
 msgstr ""
 
@@ -213,6 +233,11 @@ msgstr ""
 msgid "Document"
 msgstr ""
 
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Documentation"
+msgstr ""
+
 #: eu_einvoice/european_e_invoice/custom/sales_invoice.js:16
 msgid "Download eInvoice"
 msgstr ""
@@ -239,13 +264,13 @@ msgstr ""
 msgid "E Invoice Import"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:606
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:642
 msgid "E Invoice Import {0} does not exist"
 msgstr ""
 
 #. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
 #. Import'
-#: eu_einvoice/custom_fields.py:80
+#: eu_einvoice/custom_fields.py:101
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
 msgstr ""
@@ -260,7 +285,7 @@ msgstr ""
 msgid "E Invoice Payment Term"
 msgstr ""
 
-#: eu_einvoice/custom_fields.py:35 eu_einvoice/custom_fields.py:70
+#: eu_einvoice/custom_fields.py:42 eu_einvoice/custom_fields.py:83
 msgid "E Invoice Profile"
 msgstr ""
 
@@ -269,13 +294,22 @@ msgstr ""
 msgid "E Invoice Trade Tax"
 msgstr ""
 
-#: eu_einvoice/custom_fields.py:63
-msgid "E Invoice Validation"
+#: eu_einvoice/custom_fields.py:70
+msgid "E Invoicing"
 msgstr ""
 
 #. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
+msgstr ""
+
+#. Name of a Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "E-Invoicing"
+msgstr ""
+
+#: eu_einvoice/custom_fields.py:93
+msgid "Embedded Document"
 msgstr ""
 
 #. Label of the file_section_section (Section Break) field in DocType 'E
@@ -341,8 +375,22 @@ msgstr ""
 msgid "Net Rate"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:415
-msgid "No XML data found in PDF file."
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "New E Invoice Import"
+msgstr ""
+
+#. Label of a shortcut in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "New Sales Invoice"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:435
+msgid "No machine-readable data was found in the PDF file. You can create a regular Purchase Invoice manually instead."
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:438
+msgid "Not an E-Invoice"
 msgstr ""
 
 #. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
@@ -362,11 +410,11 @@ msgstr ""
 msgid "Payment Terms"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:114
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:115
 msgid "Please create or select a supplier before submitting"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:120
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:121
 msgid "Please map all invoice lines to an item before submitting"
 msgstr ""
 
@@ -374,7 +422,7 @@ msgstr ""
 msgid "Please note the validation errors of the e-invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:117
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:118
 msgid "Please select a company before submitting"
 msgstr ""
 
@@ -400,7 +448,7 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:600
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:636
 msgid "Purchase Invoice {0} is already linked to E Invoice Import {1}"
 msgstr ""
 
@@ -430,7 +478,7 @@ msgstr ""
 msgid "Rate Applicable Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:626
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:662
 msgid "Row {0}"
 msgstr ""
 
@@ -490,6 +538,11 @@ msgstr ""
 msgid "Settlement"
 msgstr ""
 
+#. Label of a Card Break in the E-Invoicing Workspace
+#: eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+msgid "Setup"
+msgstr ""
+
 #. Label of the supplier (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
@@ -498,6 +551,10 @@ msgstr ""
 #. Label of the supplier_address (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
+msgstr ""
+
+#: eu_einvoice/custom_fields.py:28
+msgid "Supplier Invoice File"
 msgstr ""
 
 #. Name of a role
@@ -530,7 +587,11 @@ msgstr ""
 msgid "Taxes"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:155
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:445
+msgid "The format of the uploaded file ({0}) is not supported for E-Invoices. Please upload a valid E-Invoice file or create a regular Purchase Invoice manually instead."
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:156
 msgid "The uploaded file does not contain valid XML data."
 msgstr ""
 
@@ -554,8 +615,8 @@ msgstr ""
 msgid "Unit Code"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:419
-msgid "Unsupported file format '{0}'"
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:448
+msgid "Unsupported file format"
 msgstr ""
 
 #. Description of the 'E-Invoice' (Attach) field in DocType 'E Invoice Import'
@@ -570,28 +631,34 @@ msgid "Validation Details"
 msgstr ""
 
 #. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
-#: eu_einvoice/custom_fields.py:89
+#: eu_einvoice/custom_fields.py:110
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
+msgstr ""
+
+#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
+#: eu_einvoice/custom_fields.py:119
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+msgid "Validation Warnings"
 msgstr ""
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:75
 msgid "View {0}"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:666
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:655
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:700
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:643
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:688
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:678
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:723
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,6 +4,6 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 14
+execute:from eu_einvoice.install import after_install; after_install() # 15
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import


### PR DESCRIPTION
- Adds a new "Attach" field _Embedded Document_ in **Sales Invoice**
- The attached document is included in the invoice XML as `AdditionalReferencedDocument` (BG-24)

It can be extracted from the invoice with a viewer like https://www.business-one.cloud/e-rechnung/start

Tested to work with PDF, CSV and PNG files, as well as URLs.

Todo:

- [x] Add Description to attach field