### PR TITLE
feat(Sales Invoice): make validation configurable (IBT-86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Then, you can map a **Common Code** from **Code List** "UNTDID.4461", e.g. "Cred
 
 Please note that the eInvoice standard only supports one payment means per invoice, so you should not specify multiple **Modes of Payment** in the same invoice.
 
+### E Invoice Settings
+
+eInvoice validation can be time-consuming. Use **E Invoice Settings** to configure when validation occurs and how errors are handled:
+
+- **Validate Sales Invoice on Save/Submit**: Enable or disable validation at these stages.
+- **Action on Validation Error**: Choose how to handle validation errors:
+  - *Empty* (default): No action taken
+  - *Warning Message*: Show errors but allow save/submit
+  - *Error Message*: Block save/submit and show errors
+
 ## Usage
 
 ### Sales Invoice

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -744,10 +744,18 @@ def validate_doc(doc, event):
 			indicator="orange",
 		)
 
-	validate_einvoice(doc)
+	validate_einvoice(doc, event)
 
 
-def validate_einvoice(doc: SalesInvoice):
+def validate_einvoice(doc: SalesInvoice, event: str):
+	if event not in ["before_save", "before_submit"]:
+		return
+
+	validation_state = frappe.get_single_value("E Invoice Settings", "validation_on_save_insert") if event == "before_save" else frappe.get_single_value("E Invoice Settings", "validation_on_submit")
+
+	if validation_state == "No Validation":
+		return
+
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
 	doc.validation_warnings = ""
@@ -774,11 +782,17 @@ def validate_einvoice(doc: SalesInvoice):
 
 	if any(validation_errors):
 		doc.validation_errors += "\n".join(validation_errors)
+		if validation_state == "Error":
+			frappe.throw(_("E Invoice is not correct."))
+		elif validation_state == "Warning":
+			frappe.msgprint(_("E Invoice is not correct."), alert=True, indicator="red")
 	else:
 		doc.einvoice_is_correct = 1
 
 	if any(warnings):
 		doc.validation_warnings += "\n".join(warnings)
+		if validation_state == "Warning":
+			frappe.msgprint(_("E Invoice is not correct. {0}", warnings), alert=True, indicator="orange")
 
 
 def get_item_rate(item_tax_template: str | None, taxes: list[dict]) -> float | None:

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -744,10 +744,10 @@ def validate_doc(doc, event):
 			indicator="orange",
 		)
 
-	validate_einvoice(doc, event)
+	validate_einvoice(doc)
 
 
-def validate_einvoice(doc: SalesInvoice, event: str):
+def validate_einvoice(doc: SalesInvoice):
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
 	doc.validation_warnings = ""

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -751,12 +751,12 @@ def validate_doc(doc, event):
 	if settings.should_validate(doc.docstatus):
 		validate_einvoice(doc)
 
-	if not doc.einvoice_is_correct and doc.validation_errors and settings.should_show_message(doc.docstatus):
-		frappe.msgprint(
-			msg=doc.validation_errors.replace("\n", "<br><br>"),
-			title=_("E Invoice is not correct"),
-			raise_exception=settings.should_raise_exception(doc.docstatus),
-		)
+		if not doc.einvoice_is_correct and settings.should_show_message(doc.docstatus):
+			frappe.msgprint(
+				msg=doc.validation_errors.replace("\n", "<br><br>"),
+				title=_("E Invoice is not correct"),
+				raise_exception=settings.should_raise_exception(doc.docstatus),
+			)
 
 
 def validate_einvoice(doc: SalesInvoice):

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -748,17 +748,17 @@ def validate_doc(doc, event):
 
 
 def validate_einvoice(doc: SalesInvoice, event: str):
-	if event not in ["before_save", "before_submit"]:
-		return
-
-	validation_state = frappe.get_single_value("E Invoice Settings", "validation_on_save_insert") if event == "before_save" else frappe.get_single_value("E Invoice Settings", "validation_on_submit")
-
-	if validation_state == "No Validation":
-		return
-
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
 	doc.validation_warnings = ""
+
+	settings = frappe.get_single("E Invoice Settings")
+
+	if doc.docstatus == 1 and not settings.validate_sales_invoice_on_submit:
+		return
+
+	if doc.docstatus == 0 and not settings.validate_sales_invoice_on_save:
+		return
 
 	if not doc.einvoice_profile:
 		return
@@ -782,17 +782,24 @@ def validate_einvoice(doc: SalesInvoice, event: str):
 
 	if any(validation_errors):
 		doc.validation_errors += "\n".join(validation_errors)
-		if validation_state == "Error":
-			frappe.throw(_("E Invoice is not correct."))
-		elif validation_state == "Warning":
-			frappe.msgprint(_("E Invoice is not correct."), alert=True, indicator="red")
 	else:
 		doc.einvoice_is_correct = 1
 
 	if any(warnings):
 		doc.validation_warnings += "\n".join(warnings)
-		if validation_state == "Warning":
-			frappe.msgprint(_("E Invoice is not correct. {0}", warnings), alert=True, indicator="orange")
+
+	if not doc.einvoice_is_correct and (
+		(doc.docstatus == 1 and settings.error_action_on_submit)
+		or (doc.docstatus == 0 and settings.error_action_on_save)
+	):
+		frappe.msgprint(
+			msg=doc.validation_errors.replace("\n", "<br><br>"),
+			title=_("E Invoice is not correct"),
+			raise_exception=(
+				(doc.docstatus == 1 and settings.error_action_on_submit == "Error Message")
+				or (doc.docstatus == 0 and settings.error_action_on_save == "Error Message")
+			),
+		)
 
 
 def get_item_rate(item_tax_template: str | None, taxes: list[dict]) -> float | None:

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 	from frappe.contacts.doctype.address.address import Address
 	from frappe.contacts.doctype.contact.contact import Contact
 
+	from eu_einvoice.european_e_invoice.doctype.e_invoice_settings.e_invoice_settings import EInvoiceSettings
+
 uom_codes = CommonCodeRetriever(
 	["urn:xoev-de:kosit:codeliste:rec20_3", "urn:xoev-de:kosit:codeliste:rec21_3"], "C62"
 )
@@ -744,21 +746,23 @@ def validate_doc(doc, event):
 			indicator="orange",
 		)
 
-	validate_einvoice(doc)
+	settings: EInvoiceSettings = frappe.get_single("E Invoice Settings")
+
+	if settings.should_validate(doc.docstatus):
+		validate_einvoice(doc)
+
+	if not doc.einvoice_is_correct and doc.validation_errors and settings.should_show_message(doc.docstatus):
+		frappe.msgprint(
+			msg=doc.validation_errors.replace("\n", "<br><br>"),
+			title=_("E Invoice is not correct"),
+			raise_exception=settings.should_raise_exception(doc.docstatus),
+		)
 
 
 def validate_einvoice(doc: SalesInvoice):
 	doc.einvoice_is_correct = 0
 	doc.validation_errors = ""
 	doc.validation_warnings = ""
-
-	settings = frappe.get_single("E Invoice Settings")
-
-	if doc.docstatus == 1 and not settings.validate_sales_invoice_on_submit:
-		return
-
-	if doc.docstatus == 0 and not settings.validate_sales_invoice_on_save:
-		return
 
 	if not doc.einvoice_profile:
 		return
@@ -787,19 +791,6 @@ def validate_einvoice(doc: SalesInvoice):
 
 	if any(warnings):
 		doc.validation_warnings += "\n".join(warnings)
-
-	if not doc.einvoice_is_correct and (
-		(doc.docstatus == 1 and settings.error_action_on_submit)
-		or (doc.docstatus == 0 and settings.error_action_on_save)
-	):
-		frappe.msgprint(
-			msg=doc.validation_errors.replace("\n", "<br><br>"),
-			title=_("E Invoice is not correct"),
-			raise_exception=(
-				(doc.docstatus == 1 and settings.error_action_on_submit == "Error Message")
-				or (doc.docstatus == 0 and settings.error_action_on_save == "Error Message")
-			),
-		)
 
 
 def get_item_rate(item_tax_template: str | None, taxes: list[dict]) -> float | None:

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.js
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, ALYF GmbH and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("E Invoice Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -10,12 +10,14 @@
  ],
  "fields": [
   {
+   "default": "Silent Validation",
    "fieldname": "validation_on_save_insert",
    "fieldtype": "Select",
    "label": "Validation on save/insert",
    "options": "Silent Validation\nNo Validation\nWarning\nError"
   },
   {
+   "default": "Silent Validation",
    "fieldname": "validation_on_submit",
    "fieldtype": "Select",
    "label": "Validation on submit",
@@ -26,7 +28,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-05 15:06:51.657151",
+ "modified": "2025-09-18 18:06:31.220701",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Settings",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -5,30 +5,55 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "validation_on_save_insert",
-  "validation_on_submit"
+  "sales_invoice_section",
+  "validate_sales_invoice_on_save",
+  "validate_sales_invoice_on_submit",
+  "column_break_rnbc",
+  "error_action_on_save",
+  "error_action_on_submit"
  ],
  "fields": [
   {
-   "default": "Silent Validation",
-   "fieldname": "validation_on_save_insert",
-   "fieldtype": "Select",
-   "label": "Validation on save/insert",
-   "options": "Silent Validation\nNo Validation\nWarning\nError"
+   "default": "1",
+   "fieldname": "validate_sales_invoice_on_save",
+   "fieldtype": "Check",
+   "label": "Validate Sales Invoice on Save"
   },
   {
-   "default": "Silent Validation",
-   "fieldname": "validation_on_submit",
+   "default": "1",
+   "fieldname": "validate_sales_invoice_on_submit",
+   "fieldtype": "Check",
+   "label": "Validate Sales Invoice on Submit"
+  },
+  {
+   "fieldname": "sales_invoice_section",
+   "fieldtype": "Section Break",
+   "label": "Sales Invoice"
+  },
+  {
+   "fieldname": "column_break_rnbc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "validate_sales_invoice_on_save",
+   "fieldname": "error_action_on_save",
    "fieldtype": "Select",
-   "label": "Validation on submit",
-   "options": "Silent Validation\nNo Validation\nWarning\nError"
+   "label": "Action on Validation Error during Save",
+   "options": "\nWarning Message\nError Message"
+  },
+  {
+   "depends_on": "validate_sales_invoice_on_submit",
+   "fieldname": "error_action_on_submit",
+   "fieldtype": "Select",
+   "label": "Action on Validation Error during Submit",
+   "options": "\nWarning Message\nError Message"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-18 18:06:31.220701",
+ "modified": "2025-09-18 19:27:08.732100",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Settings",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-09-05 12:02:26.455512",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "validation_on_save_insert",
+  "validation_on_submit"
+ ],
+ "fields": [
+  {
+   "fieldname": "validation_on_save_insert",
+   "fieldtype": "Select",
+   "label": "Validation on save/insert",
+   "options": "Silent Validation\nNo Validation\nWarning\nError"
+  },
+  {
+   "fieldname": "validation_on_submit",
+   "fieldtype": "Select",
+   "label": "Validation on submit",
+   "options": "Silent Validation\nNo Validation\nWarning\nError"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-09-05 15:06:51.657151",
+ "modified_by": "Administrator",
+ "module": "European e-Invoice",
+ "name": "E Invoice Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 # import frappe
+from frappe.model.docstatus import DocStatus
 from frappe.model.document import Document
 
 
@@ -25,3 +26,21 @@ class EInvoiceSettings(Document):
 			self.error_action_on_save = ""
 		if not self.validate_sales_invoice_on_submit:
 			self.error_action_on_submit = ""
+
+	def should_validate(self, docstatus: DocStatus) -> bool:
+		"""Return True if a Sales Invoice should be validated."""
+		return (docstatus == DocStatus.submitted() and self.validate_sales_invoice_on_submit) or (
+			docstatus == DocStatus.draft() and self.validate_sales_invoice_on_save
+		)
+
+	def should_raise_exception(self, docstatus: DocStatus) -> bool:
+		"""Return True if the error action is set to 'Error Message'."""
+		return (docstatus == DocStatus.submitted() and self.error_action_on_submit == "Error Message") or (
+			docstatus == DocStatus.draft() and self.error_action_on_save == "Error Message"
+		)
+
+	def should_show_message(self, docstatus: DocStatus) -> bool:
+		"""Return True if any error action is set."""
+		return (docstatus == DocStatus.submitted() and self.error_action_on_submit) or (
+			docstatus == DocStatus.draft() and self.error_action_on_save
+		)

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025, ALYF GmbH and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class EInvoiceSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		validation_on_save_insert: DF.Literal["Silent Validation", "No Validation", "Warning", "Error"]
+		validation_on_submit: DF.Literal["Silent Validation", "No Validation", "Warning", "Error"]
+	# end: auto-generated types
+
+	pass

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -14,8 +14,14 @@ class EInvoiceSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		validation_on_save_insert: DF.Literal["Silent Validation", "No Validation", "Warning", "Error"]
-		validation_on_submit: DF.Literal["Silent Validation", "No Validation", "Warning", "Error"]
+		error_action_on_save: DF.Literal["", "Warning Message", "Error Message"]
+		error_action_on_submit: DF.Literal["", "Warning Message", "Error Message"]
+		validate_sales_invoice_on_save: DF.Check
+		validate_sales_invoice_on_submit: DF.Check
 	# end: auto-generated types
 
-	pass
+	def before_validate(self):
+		if not self.validate_sales_invoice_on_save:
+			self.error_action_on_save = ""
+		if not self.validate_sales_invoice_on_submit:
+			self.error_action_on_submit = ""

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/test_e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/test_e_invoice_settings.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025, ALYF GmbH and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestEInvoiceSettings(IntegrationTestCase):
+	"""
+	Integration tests for EInvoiceSettings.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
+++ b/eu_einvoice/european_e_invoice/workspace/e_invoicing/e_invoicing.json
@@ -19,7 +19,7 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Setup",
-   "link_count": 2,
+   "link_count": 3,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -43,9 +43,19 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "E Invoice Settings",
+   "link_count": 0,
+   "link_to": "E Invoice Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2025-03-07 07:17:56.903277",
+ "modified": "2025-09-18 19:30:29.015365",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E-Invoicing",

--- a/eu_einvoice/hooks.py
+++ b/eu_einvoice/hooks.py
@@ -143,8 +143,7 @@ after_install = "eu_einvoice.install.after_install"
 
 doc_events = {
 	"Sales Invoice": {
-		"before_submit": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
-		"before_save": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
+		"validate": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
 	}
 }
 

--- a/eu_einvoice/hooks.py
+++ b/eu_einvoice/hooks.py
@@ -143,7 +143,8 @@ after_install = "eu_einvoice.install.after_install"
 
 doc_events = {
 	"Sales Invoice": {
-		"validate": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
+		"before_submit": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
+		"before_save": "eu_einvoice.european_e_invoice.custom.sales_invoice.validate_doc",
 	}
 }
 

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-08-26 12:21+0053\n"
+"POT-Creation-Date: 2025-09-18 19:28+0053\n"
 "PO-Revision-Date: 2024-11-25 18:57+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:732
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:742
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht unterstützt."
 
@@ -26,6 +26,18 @@ msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht un
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
 msgstr ""
+
+#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Action on Validation Error during Save"
+msgstr "Aktion bei Validierungsfehler beim Speichern"
+
+#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Action on Validation Error during Submit"
+msgstr "Aktion bei Validierungsfehler beim Buchen"
 
 #. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
 #. Payment Term'
@@ -149,11 +161,11 @@ msgstr "Berechneter Betrag"
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:751
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:769
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:762
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:780
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
@@ -292,9 +304,18 @@ msgid "E Invoice Profile"
 msgstr "E-Rechnungs-Profil"
 
 #. Name of a DocType
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "E Invoice Settings"
+msgstr "E-Rechnungs-Einstellungen"
+
+#. Name of a DocType
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "E Invoice Trade Tax"
 msgstr "E-Rechnungs-Steuer"
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:797
+msgid "E Invoice is not correct"
+msgstr "E-Rechnung ist nicht korrekt"
 
 #: eu_einvoice/custom_fields.py:70
 msgid "E Invoicing"
@@ -313,6 +334,13 @@ msgstr "E-Rechnung"
 #: eu_einvoice/custom_fields.py:93
 msgid "Embedded Document"
 msgstr ""
+
+#. Option for the 'Action on Validation Error during Save' (Select) field in
+#. DocType 'E Invoice Settings'
+#. Option for the 'Action on Validation Error during Submit' (Select) field in
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Error Message"
+msgstr "Fehlermeldung"
 
 #. Label of the file_section_section (Section Break) field in DocType 'E
 #. Invoice Import'
@@ -484,6 +512,12 @@ msgstr "Anwendbarer Prozentsatz"
 msgid "Row {0}"
 msgstr "Zeile {0}"
 
+#. Label of the sales_invoice_section (Section Break) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Sales Invoice"
+msgstr ""
+
 #. Label of the seller_section (Section Break) field in DocType 'E Invoice
 #. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -561,6 +595,7 @@ msgstr "Lieferantenrechnungsdatei"
 
 #. Name of a role
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "System Manager"
 msgstr ""
 
@@ -626,6 +661,18 @@ msgstr "Nicht unterstütztes Dateiformat"
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr "Laden Sie die von Ihrem Lieferanten bereitgestellte <code>.xml</code>- oder <code>.pdf</code>-Datei hoch."
 
+#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Validate Sales Invoice on Save"
+msgstr "E-Rechnung beim Speichern validieren"
+
+#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Validate Sales Invoice on Submit"
+msgstr "E-Rechnung beim Buchen validieren"
+
 #. Label of the validation_details_section (Section Break) field in DocType 'E
 #. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -648,19 +695,26 @@ msgstr "Validierungswarnungen"
 msgid "View {0}"
 msgstr "{0} ansehen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
+#. Option for the 'Action on Validation Error during Save' (Select) field in
+#. DocType 'E Invoice Settings'
+#. Option for the 'Action on Validation Error during Submit' (Select) field in
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Warning Message"
+msgstr "Warnung"
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:721
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:700
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:710
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr "Die Gebührenart 'Tatsächlich' wird nur in den E-Rechnungs-Profilen 'EXTENDED' und 'XRECHNUNG' unterstützt."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:688
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:698
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:723
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:733
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2025-08-26 12:21+0053\n"
-"PO-Revision-Date: 2025-08-26 12:21+0053\n"
+"POT-Creation-Date: 2025-09-18 19:28+0053\n"
+"PO-Revision-Date: 2025-09-18 19:28+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -16,13 +16,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:732
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:742
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr ""
 
 #. Label of the payee_account_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
+msgstr ""
+
+#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Action on Validation Error during Save"
+msgstr ""
+
+#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Action on Validation Error during Submit"
 msgstr ""
 
 #. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
@@ -147,11 +159,11 @@ msgstr ""
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:751
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:769
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:762
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:780
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
@@ -290,8 +302,17 @@ msgid "E Invoice Profile"
 msgstr ""
 
 #. Name of a DocType
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "E Invoice Settings"
+msgstr ""
+
+#. Name of a DocType
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "E Invoice Trade Tax"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:797
+msgid "E Invoice is not correct"
 msgstr ""
 
 #: eu_einvoice/custom_fields.py:70
@@ -310,6 +331,14 @@ msgstr ""
 
 #: eu_einvoice/custom_fields.py:93
 msgid "Embedded Document"
+msgstr ""
+
+#. Option for the 'Action on Validation Error during Save' (Select) field in
+#. DocType 'E Invoice Settings'
+#. Option for the 'Action on Validation Error during Submit' (Select) field in
+#. DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Error Message"
 msgstr ""
 
 #. Label of the file_section_section (Section Break) field in DocType 'E
@@ -482,6 +511,12 @@ msgstr ""
 msgid "Row {0}"
 msgstr ""
 
+#. Label of the sales_invoice_section (Section Break) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Sales Invoice"
+msgstr ""
+
 #. Label of the seller_section (Section Break) field in DocType 'E Invoice
 #. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -559,6 +594,7 @@ msgstr ""
 
 #. Name of a role
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "System Manager"
 msgstr ""
 
@@ -624,6 +660,18 @@ msgstr ""
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr ""
 
+#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Validate Sales Invoice on Save"
+msgstr ""
+
+#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Validate Sales Invoice on Submit"
+msgstr ""
+
 #. Label of the validation_details_section (Section Break) field in DocType 'E
 #. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -646,19 +694,27 @@ msgstr ""
 msgid "View {0}"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:711
+#. Option for the 'Action on Validation Error during Save' (Select) field in
+#. DocType 'E Invoice Settings'
+#. Option for the 'Action on Validation Error during Submit' (Select) field in
+#. DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Warning Message"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:721
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:700
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:710
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:688
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:698
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:723
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:733
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -7,3 +7,4 @@
 execute:from eu_einvoice.install import after_install; after_install() # 15
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import
+eu_einvoice.patches.set_default_settings

--- a/eu_einvoice/patches/set_default_settings.py
+++ b/eu_einvoice/patches/set_default_settings.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	"""Set the default settings for the new 'E Invoice Settings' doctype."""
+	settings = frappe.get_single("E Invoice Settings")
+	settings.validate_sales_invoice_on_save = 1
+	settings.validate_sales_invoice_on_submit = 1
+	settings.error_action_on_save = ""
+	settings.error_action_on_submit = ""
+	settings.save()


### PR DESCRIPTION
Added support for configurable validation behavior with two kinds of settings:

- Turn validation on or off, separately for save and submit events
- Add an option to show either a warning or an error when the validation runs and fails

Other related work:

- Add link to new settings page to workspace
- Update German translations
- Patch to add default settings so that the behavior remains unchanged unless the user adjust the settings

Resolves #159