### PR TITLE
fix: capture basic warnings

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -768,6 +768,7 @@ def validate_einvoice(doc: SalesInvoice):
 		if invoice_profile == EInvoiceProfile.XRECHNUNG:
 			basic_errors, basic_warnings = get_validation_errors(xml_string, EInvoiceProfile.EN16931)
 			validation_errors += basic_errors
+			warnings += basic_warnings
 	except Exception:
 		doc.validation_errors = _("Cannot validate E Invoice schematron.")
 		return

--- a/eu_einvoice/schematron/__init__.py
+++ b/eu_einvoice/schematron/__init__.py
@@ -13,11 +13,11 @@ PROFILE_TO_XSL = {
 }
 
 
-def get_validation_errors(xml_string: str, profile: EInvoiceProfile) -> list[str]:
+def get_validation_errors(xml_string: str, profile: EInvoiceProfile):
 	return get_errors_from_stylesheet(xml_string, PROFILE_TO_XSL[profile])
 
 
-def get_errors_from_stylesheet(xml_string: str, stylesheet: str) -> list[str]:
+def get_errors_from_stylesheet(xml_string: str, stylesheet: str):
 	stylesheet_path = Path(__file__).parent / stylesheet
 	report = get_validation_report(xml_string, str(stylesheet_path))
 	return extract_failed_asserts(report)


### PR DESCRIPTION
In the case of XRECHNUNG, the warnings generated by `EInvoiceProfile.EN16931` were previously discarded. Now we show them.
