### PR TITLE
fix(Sales Invoice): don't copy einvoice_is_correct and validation_errors/warnings

### DIFF
--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -103,6 +103,7 @@ def get_custom_fields():
 				"fieldtype": "Check",
 				"read_only": 1,
 				"print_hide": 1,
+				"no_copy": 1,
 				"depends_on": "eval:!!doc.einvoice_profile",
 			},
 			{
@@ -112,6 +113,7 @@ def get_custom_fields():
 				"fieldtype": "Text",
 				"read_only": 1,
 				"print_hide": 1,
+				"no_copy": 1,
 				"depends_on": "eval:doc.einvoice_profile && !doc.einvoice_is_correct",
 			},
 			{
@@ -121,6 +123,7 @@ def get_custom_fields():
 				"fieldtype": "Text",
 				"read_only": 1,
 				"print_hide": 1,
+				"no_copy": 1,
 				"depends_on": "eval:doc.einvoice_profile && doc.validation_warnings",
 			},
 		],

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,7 +4,7 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 15
+execute:from eu_einvoice.install import after_install; after_install() # 16
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import
 eu_einvoice.patches.set_default_settings


### PR DESCRIPTION
Enable _No Copy_ for three custom fields in **Sales Invoice**:

1. _E Invoice Is Correct_
2. _Validation Errors_
3. _Validation Warnings_

These only make sense for the current doc and need to be recalculated for a new doc.

Re-runs patch to update fields in existing installations.