### PR TITLE
chore: add linguist config via .gitattribbutes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+eu_einvoice/schematron/*.xml linguist-vendored
+eu_einvoice/schematron/*.xsl linguist-vendored
+eu_einvoice/locale/* linguist-generated


### PR DESCRIPTION
Linguist is used on GitHub.com to detect blob languages, ignore binary or vendored files, suppress generated files in diffs, and generate language breakdown graphs.

Ref: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
