### PR TITLE
feat: electronic address of buyer and seller

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Code List | Mapped DocType | Default Value
 [Codes for Passengers, Types of Cargo, Packages and Packaging Materials](https://www.xrepository.de/api/xrepository/urn:xoev-de:kosit:codeliste:rec21_3:technischerBestandteilGenericode) (optional) | UOM | C62
 [Codes for Duty Tax and Fee Categories](https://www.xrepository.de/api/xrepository/urn:xoev-de:kosit:codeliste:untdid.5305_3:technischerBestandteilGenericode) | Item Tax Template, Account, Tax Category, Sales Taxes and Charges Template | S
 [VAT exemption reason code list](https://www.xrepository.de/api/xrepository/urn:xoev-de:kosit:codeliste:vatex_1:technischerBestandteilGenericode) | Item Tax Template, Account, Tax Category, Sales Taxes and Charges Template | vatex-eu-ae
+[Electronic Address Scheme](https://www.xrepository.de/api/xrepository/urn:xoev-de:kosit:codeliste:eas_5:technischerBestandteilGenericode) (Mapping: _as Title_: scheme-name, _as Code_: aesc, _as Description_: remark) | N/A | EM
 
 For example, let's say your standard **Payment Terms Template** is "Bank Transfer, 30 days". You'll need to find the suitable **Common Code** for bank transfers within the **Code List** "UNTDID.4461". In this case, the code is "58". Then you add a row to the _Applies To_ table, select "Payment Terms Template" as the _Link Document Type_ and "Bank Transfer, 30 days" as the _Link Name_. If you now create an Invoice with this **Payment Terms Template**, the eInvoice will contain the code "58" for the payment means, signalling that the payment should done via bank transfer.
 
@@ -59,6 +60,14 @@ The national terms for this field are:
 
 - Germany: _Leitweg-ID_
 - France: _Code Service_
+
+### Electronic Address
+
+If you send your invoice via PEPPOL, you might need to specify your and your customer's electronic addresses. This is done by setting the _Electronic Address Scheme_ and _Electronic Address_ fields in the **Company**, **Customer** and **Supplier** master data.
+
+Please make sure to import the **Electronic Address Scheme** code list first.
+
+If not specified, email addresses are used as electronic addresses for outgoing invoices. For the Customer, we use the _Contact Email_ or _Buyer Address_ > _Email ID_. For the Company, we use the _Seller Contact_ > _Email ID_ or _Company_ > _Email_.
 
 ### Bank Details
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - Phone No
     - Email
     - Fax
+    - Electronic Address Scheme
+    - Electronic Address
 - Company Name
 - Company Address
     - Address Line 1
@@ -123,6 +125,9 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - Phone (takes precedence over Company > Phone No)
     - Department
 - Company Tax ID
+- Customer
+    - Electronic Address Scheme
+    - Electronic Address
 - Customer Name
 - Buyer Reference (fetched from **Sales Order** or **Customer**)
 - Customer Address
@@ -132,7 +137,7 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - City
     - Country
     - Email ID (only if Contact Email is not set)
-- Contact Email (Used as buyer electronic address, BT-49. Falls back to Email ID from Customer Address if missing.)
+- Contact Email
 - Contact Person
     - Full Name
     - Phone (takes precedence over Mobile No)
@@ -256,6 +261,8 @@ The following fields are currently imported from the eInvoice:
 - Seller (Supplier)
     - Name
     - Tax ID
+    - Electronic Address Scheme
+    - Electronic Address
     - Address
         - Address Line 1
         - Address Line 2
@@ -264,6 +271,8 @@ The following fields are currently imported from the eInvoice:
         - Country
 - Buyer (Company)
     - Name
+    - Electronic Address Scheme
+    - Electronic Address
     - Address
         - Address Line 1
         - Address Line 2

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -51,6 +51,64 @@ def get_custom_fields():
 				"options": PROFILE_OPTIONS,
 				"default": "EXTENDED",
 			},
+			{
+				"fieldname": "electronic_address_scheme",
+				"label": _("Electronic Address Scheme"),
+				"insert_after": "einvoice_profile",
+				"fieldtype": "Link",
+				"options": "Common Code",
+			},
+			{
+				"fieldname": "electronic_address",
+				"label": _("Electronic Address"),
+				"insert_after": "electronic_address_scheme",
+				"fieldtype": "Data",
+				"depends_on": "electronic_address_scheme",
+			},
+		],
+		"Company": [
+			{
+				"fieldname": "einvoice_tab",
+				"label": _("E Invoicing"),
+				"insert_after": "default_operating_cost_account",
+				"fieldtype": "Tab Break",
+			},
+			{
+				"fieldname": "electronic_address_scheme",
+				"label": _("Electronic Address Scheme"),
+				"insert_after": "einvoice_tab",
+				"fieldtype": "Link",
+				"options": "Common Code",
+			},
+			{
+				"fieldname": "electronic_address",
+				"label": _("Electronic Address"),
+				"insert_after": "electronic_address_scheme",
+				"fieldtype": "Data",
+				"depends_on": "electronic_address_scheme",
+			},
+		],
+		"Supplier": [
+			{
+				"fieldname": "einvoice_tab",
+				"label": _("E Invoicing"),
+				"insert_after": "portal_users",
+				"fieldtype": "Tab Break",
+			},
+			{
+				"fieldname": "electronic_address_scheme",
+				"label": _("Electronic Address Scheme"),
+				"insert_after": "einvoice_tab",
+				"fieldtype": "Link",
+				"options": "Common Code",
+			},
+			{
+				"fieldname": "electronic_address",
+				"label": _("Electronic Address"),
+				"insert_after": "electronic_address_scheme",
+				"fieldtype": "Data",
+				"depends_on": "electronic_address_scheme",
+			},
 		],
 		"Sales Order": [
 			{

--- a/eu_einvoice/custom_fields.py
+++ b/eu_einvoice/custom_fields.py
@@ -32,9 +32,15 @@ def get_custom_fields():
 		],
 		"Customer": [
 			{
+				"fieldname": "einvoice_tab",
+				"label": _("E Invoicing"),
+				"insert_after": "portal_users",
+				"fieldtype": "Tab Break",
+			},
+			{
 				"fieldname": "buyer_reference",
 				"label": _("Buyer Reference"),
-				"insert_after": "language",
+				"insert_after": "einvoice_tab",
 				"fieldtype": "Data",
 			},
 			{

--- a/eu_einvoice/european_e_invoice/custom/company.js
+++ b/eu_einvoice/european_e_invoice/custom/company.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Company", {
+	setup: function (frm) {
+		frm.set_query("electronic_address_scheme", eu_einvoice.queries.electronic_address_scheme);
+	},
+});

--- a/eu_einvoice/european_e_invoice/custom/customer.js
+++ b/eu_einvoice/european_e_invoice/custom/customer.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Customer", {
+	setup: function (frm) {
+		frm.set_query("electronic_address_scheme", eu_einvoice.queries.electronic_address_scheme);
+	},
+});

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -299,6 +299,13 @@ class EInvoiceGenerator:
 		).upper()
 
 	def _set_seller_electronic_address(self):
+		if self.company.electronic_address_scheme and self.company.electronic_address:
+			self.doc.trade.agreement.seller.electronic_address.uri_ID = (
+				frappe.db.get_value("Common Code", self.company.electronic_address_scheme, "common_code"),
+				self.company.electronic_address,
+			)
+			return
+
 		if self.seller_contact and self.seller_contact.email_id:
 			electronic_address = self.seller_contact.email_id
 		else:
@@ -336,12 +343,21 @@ class EInvoiceGenerator:
 		if self.profile > EInvoiceProfile.BASIC:
 			self._set_buyer_contact()
 
+		self._set_buyer_electronic_address()
+		self._set_buyer_tax_id()
+
+	def _set_buyer_electronic_address(self):
+		if self.customer.electronic_address_scheme and self.customer.electronic_address:
+			self.doc.trade.agreement.buyer.electronic_address.uri_ID = (
+				frappe.db.get_value("Common Code", self.customer.electronic_address_scheme, "common_code"),
+				self.customer.electronic_address,
+			)
+			return
+
 		if self.invoice.contact_email:
 			self.doc.trade.agreement.buyer.electronic_address.uri_ID = ("EM", self.invoice.contact_email)
 		elif self.buyer_address.email_id:
 			self.doc.trade.agreement.buyer.electronic_address.uri_ID = ("EM", self.buyer_address.email_id)
-
-		self._set_buyer_tax_id()
 
 	def _set_buyer_tax_id(self):
 		if not self.invoice.tax_id:

--- a/eu_einvoice/european_e_invoice/custom/supplier.js
+++ b/eu_einvoice/european_e_invoice/custom/supplier.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("Supplier", {
+	setup: function (frm) {
+		frm.set_query("electronic_address_scheme", eu_einvoice.queries.electronic_address_scheme);
+	},
+});

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -24,6 +24,10 @@
   "column_break_metg",
   "company",
   "purchase_order",
+  "section_break_oyba",
+  "buyer_electronic_address_scheme",
+  "column_break_remv",
+  "buyer_electronic_address",
   "section_break_qegd",
   "column_break_reul",
   "buyer_address_line_1",
@@ -38,6 +42,10 @@
   "column_break_jjaa",
   "supplier",
   "create_supplier",
+  "section_break_sqyh",
+  "seller_electronic_address_scheme",
+  "column_break_qxvl",
+  "seller_electronic_address",
   "section_break_lrsy",
   "seller_address_line_1",
   "seller_address_line_2",
@@ -480,6 +488,46 @@
   {
    "fieldname": "section_break_lrsy",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "buyer_electronic_address_scheme",
+   "fieldtype": "Data",
+   "label": "Buyer Electronic Address Scheme",
+   "read_only": 1
+  },
+  {
+   "fieldname": "buyer_electronic_address",
+   "fieldtype": "Data",
+   "label": "Buyer Electronic Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "seller_electronic_address_scheme",
+   "fieldtype": "Data",
+   "label": "Seller Electronic Address Scheme",
+   "read_only": 1
+  },
+  {
+   "fieldname": "seller_electronic_address",
+   "fieldtype": "Data",
+   "label": "Seller Electronic Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_oyba",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_remv",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_sqyh",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_qxvl",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -490,7 +538,7 @@
    "link_fieldname": "e_invoice_import"
   }
  ],
- "modified": "2025-10-04 17:52:04.926238",
+ "modified": "2025-10-04 18:04:03.032057",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Import",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
@@ -19,31 +19,34 @@
   "id",
   "section_break_z2sq",
   "amended_from",
-  "agreement_tab",
-  "seller_section",
-  "seller_name",
-  "seller_tax_id",
-  "seller_address_line_1",
-  "seller_address_line_2",
-  "seller_postcode",
-  "seller_city",
-  "seller_country",
-  "column_break_foui",
-  "supplier",
-  "create_supplier",
-  "supplier_address",
-  "create_supplier_address",
-  "buyer_section",
-  "column_break_reul",
+  "buyer_tab",
   "buyer_name",
+  "column_break_metg",
+  "company",
+  "purchase_order",
+  "section_break_qegd",
+  "column_break_reul",
   "buyer_address_line_1",
   "buyer_address_line_2",
   "buyer_postcode",
   "buyer_city",
   "buyer_country",
   "column_break_ldwo",
-  "company",
-  "purchase_order",
+  "seller_tab",
+  "seller_name",
+  "seller_tax_id",
+  "column_break_jjaa",
+  "supplier",
+  "create_supplier",
+  "section_break_lrsy",
+  "seller_address_line_1",
+  "seller_address_line_2",
+  "seller_postcode",
+  "seller_city",
+  "seller_country",
+  "column_break_foui",
+  "supplier_address",
+  "create_supplier_address",
   "items_tab",
   "items",
   "delivery_tab",
@@ -281,11 +284,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "buyer_section",
-   "fieldtype": "Section Break",
-   "label": "Buyer"
-  },
-  {
    "fieldname": "column_break_ldwo",
    "fieldtype": "Column Break"
   },
@@ -303,17 +301,6 @@
    "fieldname": "settlement_tab",
    "fieldtype": "Tab Break",
    "label": "Settlement"
-  },
-  {
-   "depends_on": "einvoice",
-   "fieldname": "agreement_tab",
-   "fieldtype": "Tab Break",
-   "label": "Agreement"
-  },
-  {
-   "fieldname": "seller_section",
-   "fieldtype": "Section Break",
-   "label": "Seller"
   },
   {
    "fieldname": "due_date",
@@ -467,6 +454,32 @@
    "fieldtype": "Text",
    "label": "Validation Warnings",
    "read_only": 1
+  },
+  {
+   "fieldname": "buyer_tab",
+   "fieldtype": "Tab Break",
+   "label": "Buyer"
+  },
+  {
+   "fieldname": "column_break_metg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_qegd",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "seller_tab",
+   "fieldtype": "Tab Break",
+   "label": "Seller"
+  },
+  {
+   "fieldname": "column_break_jjaa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_lrsy",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -477,7 +490,7 @@
    "link_fieldname": "e_invoice_import"
   }
  ],
- "modified": "2025-05-07 00:53:28.840615",
+ "modified": "2025-10-04 17:52:04.926238",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Import",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -52,6 +52,8 @@ class EInvoiceImport(Document):
 		buyer_address_line_2: DF.Data | None
 		buyer_city: DF.Data | None
 		buyer_country: DF.Link | None
+		buyer_electronic_address: DF.Data | None
+		buyer_electronic_address_scheme: DF.Data | None
 		buyer_name: DF.Data | None
 		buyer_postcode: DF.Data | None
 		charge_total: DF.Currency
@@ -76,6 +78,8 @@ class EInvoiceImport(Document):
 		seller_address_line_2: DF.Data | None
 		seller_city: DF.Data | None
 		seller_country: DF.Link | None
+		seller_electronic_address: DF.Data | None
+		seller_electronic_address_scheme: DF.Data | None
 		seller_name: DF.Data | None
 		seller_postcode: DF.Data | None
 		seller_tax_id: DF.Data | None
@@ -224,10 +228,14 @@ class EInvoiceImport(Document):
 		self.seller_tax_id = (
 			seller.tax_registrations.children[0].id._text if seller.tax_registrations.children else None
 		)
+		self.seller_electronic_address = str(seller.electronic_address.uri_ID._text)
+		self.seller_electronic_address_scheme = str(seller.electronic_address.uri_ID._scheme_id)
 		self.parse_address(seller.address, "seller")
 
 	def parse_buyer(self, buyer: "TradeParty"):
 		self.buyer_name = str(buyer.name)
+		self.buyer_electronic_address = str(buyer.electronic_address.uri_ID._text)
+		self.buyer_electronic_address_scheme = str(buyer.electronic_address.uri_ID._scheme_id)
 		self.parse_address(buyer.address, "buyer")
 
 	def parse_address(self, address: "PostalTradeAddress", prefix: str) -> _dict:

--- a/eu_einvoice/hooks.py
+++ b/eu_einvoice/hooks.py
@@ -26,7 +26,7 @@ required_apps = ["frappe/erpnext"]
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/eu_einvoice/css/eu_einvoice.css"
-app_include_js = "/assets/eu_einvoice/js/utils.js"
+app_include_js = ["/assets/eu_einvoice/js/utils.js", "/assets/eu_einvoice/js/queries.js"]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/eu_einvoice/css/eu_einvoice.css"
@@ -46,6 +46,9 @@ app_include_js = "/assets/eu_einvoice/js/utils.js"
 doctype_js = {
 	"Purchase Order": "european_e_invoice/custom/purchase_order.js",
 	"Sales Invoice": "european_e_invoice/custom/sales_invoice.js",
+	"Company": "european_e_invoice/custom/company.js",
+	"Customer": "european_e_invoice/custom/customer.js",
+	"Supplier": "european_e_invoice/custom/supplier.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -4,7 +4,7 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 16
+execute:from eu_einvoice.install import after_install; after_install() # 17
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import
 eu_einvoice.patches.set_default_settings

--- a/eu_einvoice/public/js/queries.js
+++ b/eu_einvoice/public/js/queries.js
@@ -1,0 +1,14 @@
+frappe.provide("eu_einvoice.queries");
+
+eu_einvoice.queries = {
+	electronic_address_scheme: function (doc) {
+		return {
+			filters: {
+				canonical_uri: [
+					"in",
+					["urn:xoev-de:kosit:codeliste:eas", "urn:cef.eu:names:identifier:EAS"],
+				],
+			},
+		};
+	},
+};


### PR DESCRIPTION
This pull request introduces support for electronic address schemes in the European e-Invoice workflow, enabling more accurate and standardized handling of electronic addresses for companies, customers, and suppliers. The changes span documentation, custom fields, import/export logic, and UI enhancements to ensure the correct electronic address information is captured and displayed throughout the system.

**Electronic Address Scheme Support**

* Added _Electronic Address Scheme_ and _Electronic Address_ fields to the **Company**, **Customer**, and **Supplier** master data, with corresponding tab breaks for better UI organization in `eu_einvoice/custom_fields.py`. These fields are linked to the standardized **Common Code** list.
* Implemented client-side filtering for the _Electronic Address Scheme_ field in the **Company**, **Customer**, and **Supplier** forms, ensuring only valid schemes are selectable via a shared query in `eu_einvoice/public/js/queries.js` and respective form scripts. (Depends on https://github.com/frappe/erpnext/pull/49882.)
* Updated the e-invoice import logic to parse and store electronic address scheme and address for both buyer and seller, and added these fields to the import doctype and its JSON definition for display and mapping.
* Enhanced sales invoice generation to correctly set electronic address and scheme for both seller and buyer, prioritizing master data fields and falling back to email addresses when not specified.

**Documentation and Configuration Updates**

* Updated documentation in `README.md` to explain how electronic addresses and schemes work, including mapping instructions and fallback logic for email addresses.
* Registered new JavaScript files and form scripts for Company, Customer, and Supplier doctypes in `eu_einvoice/hooks.py` and incremented the patch version in `eu_einvoice/patches.txt` for deployment.
