### PR TITLE
fix: add patch to remove v15 custom fields in v16

### DIFF
--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -1,6 +1,7 @@
 [pre_model_sync]
 # Patches added in this section will be executed before doctypes are migrated
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
+eu_einvoice.patches.delete_custom_numbers_fields #1
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated

--- a/eu_einvoice/patches/delete_custom_numbers_fields.py
+++ b/eu_einvoice/patches/delete_custom_numbers_fields.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	"""
+	In ERPNext v15 we've added Custom Fields for supplier number at customer
+	and customer number at supplier. In ERPNext v16 they're part of ERPNext, so
+	we remove them here.
+	"""
+	frappe.delete_doc_if_exists("Custom Field", "Customer-supplier_numbers")
+	frappe.delete_doc_if_exists("Custom Field", "Supplier-customer_numbers")


### PR DESCRIPTION
In ERPNext v15 we've added Custom Fields for supplier number at customer and customer number at supplier.
In ERPNext v16 they're part of ERPNext, so we remove them here.
