### PR TITLE
fix: set name of ShipToTradeParty

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ The following fields of the **Sales Invoice** are currently considered for the e
     - Email Address
     - Mobile No
     - Department
+- Shipping Address
+    - Address Title (falls back to _Customer Name_)
+    - Address Line 1
+    - Address Line 2
+    - Postcode
+    - City
+    - Country
 - Customer's Purchase Order
 - Customer's Purchase Order Date
 - Customer's Tax ID

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -392,6 +392,9 @@ class EInvoiceGenerator:
 		if not self.shipping_address:
 			return
 
+		self.doc.trade.delivery.ship_to.name = (
+			self.shipping_address.address_title or self.invoice.customer_name
+		)
 		self.doc.trade.delivery.ship_to.address.line_one = self.shipping_address.address_line1
 		self.doc.trade.delivery.ship_to.address.line_two = self.shipping_address.address_line2
 		self.doc.trade.delivery.ship_to.address.postcode = self.shipping_address.pincode


### PR DESCRIPTION
Enhancements to shipping address handling:

* Updated the documentation in `README.md` to list the shipping address fields now included for sales invoice export, specifying each component (address title, lines, postcode, city, country).
* Modified the `_set_shipping_address` method in `eu_einvoice/european_e_invoice/custom/sales_invoice.py` to populate the shipping address fields in the export, using the address title if available or falling back to the customer name.