### PR TITLE
fix: avoid type error when buyer_address is not set

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -356,7 +356,7 @@ class EInvoiceGenerator:
 
 		if self.invoice.contact_email:
 			self.doc.trade.agreement.buyer.electronic_address.uri_ID = ("EM", self.invoice.contact_email)
-		elif self.buyer_address.email_id:
+		elif self.buyer_address and self.buyer_address.email_id:
 			self.doc.trade.agreement.buyer.electronic_address.uri_ID = ("EM", self.buyer_address.email_id)
 
 	def _set_buyer_tax_id(self):


### PR DESCRIPTION
Resolves this error that occurs when _Customer Address_ is not set in a **Sales Invoice**:

```
Traceback with variables (most recent call last):
  File "apps/eu_einvoice/eu_einvoice/european_e_invoice/custom/sales_invoice.py", line 804, in validate_einvoice
    xml_string = get_einvoice(doc).decode()
      doc = Sales Invoice (ACC-SINV-2025-00006)
      msg = 'Cannot create E Invoice.'
  File "apps/eu_einvoice/eu_einvoice/european_e_invoice/custom/sales_invoice.py", line 93, in get_einvoice
    generator.create_einvoice()
      invoice = Sales Invoice (ACC-SINV-2025-00006)
      seller_address = None
      buyer_address = None
      shipping_address = None
      seller_contact = None
      buyer_contact = None
      customer = Customer (Grant Plastics Ltd.)
      company = Company (ALYF GmbH)
      profile = EInvoiceProfile.BASIC
      generator = eu_einvoice.european_e_invoice.custom.sales_invoice.EInvoiceGenerator(buyer_address=None, buyer_contact=None, company=Company (ALYF GmbH), customer=Customer (Grant Plastics Ltd.), delivery_dates=[], doc=drafthorse.models.document.Document(-), invoice=Sales Invoice (ACC-SINV-2025-00006), item_tax_rates=set(), profile=EInvoiceProfile.BASIC, seller_address=None, seller_contact=None, shipping_address=None)
  File "apps/eu_einvoice/eu_einvoice/european_e_invoice/custom/sales_invoice.py", line 140, in create_einvoice
    self._set_buyer()
      self = eu_einvoice.european_e_invoice.custom.sales_invoice.EInvoiceGenerator(buyer_address=None, buyer_contact=None, company=Company (ALYF GmbH), customer=Customer (Grant Plastics Ltd.), delivery_dates=[], doc=drafthorse.models.document.Document(-), invoice=Sales Invoice (ACC-SINV-2025-00006), item_tax_rates=set(), profile=EInvoiceProfile.BASIC, seller_address=None, seller_contact=None, shipping_address=None)
  File "apps/eu_einvoice/eu_einvoice/european_e_invoice/custom/sales_invoice.py", line 346, in _set_buyer
    self._set_buyer_electronic_address()
      self = eu_einvoice.european_e_invoice.custom.sales_invoice.EInvoiceGenerator(buyer_address=None, buyer_contact=None, company=Company (ALYF GmbH), customer=Customer (Grant Plastics Ltd.), delivery_dates=[], doc=drafthorse.models.document.Document(-), invoice=Sales Invoice (ACC-SINV-2025-00006), item_tax_rates=set(), profile=EInvoiceProfile.BASIC, seller_address=None, seller_contact=None, shipping_address=None)
  File "apps/eu_einvoice/eu_einvoice/european_e_invoice/custom/sales_invoice.py", line 359, in _set_buyer_electronic_address
    elif self.buyer_address.email_id:
      self = eu_einvoice.european_e_invoice.custom.sales_invoice.EInvoiceGenerator(buyer_address=None, buyer_contact=None, company=Company (ALYF GmbH), customer=Customer (Grant Plastics Ltd.), delivery_dates=[], doc=drafthorse.models.document.Document(-), invoice=Sales Invoice (ACC-SINV-2025-00006), item_tax_rates=set(), profile=EInvoiceProfile.BASIC, seller_address=None, seller_contact=None, shipping_address=None)
builtins.AttributeError: 'NoneType' object has no attribute 'email_id'
```

Introduced in #177