### PR TITLE
fix: pass generator param to download_pdf

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -4,7 +4,7 @@ import mimetypes
 import os
 import re
 from base64 import b64encode
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal
 
 import frappe
 from drafthorse.models.accounting import ApplicableTradeTax, AppliedTradeTax
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 	from erpnext.setup.doctype.company.company import Company
 	from frappe.contacts.doctype.address.address import Address
 	from frappe.contacts.doctype.contact.contact import Contact
+	from frappe.model.document import Document as FrappeDocument
 
 	from eu_einvoice.european_e_invoice.doctype.e_invoice_settings.e_invoice_settings import EInvoiceSettings
 
@@ -996,12 +997,12 @@ def as_base_64(content: str | bytes) -> str:
 def download_pdf(
 	doctype: str,
 	name: str,
-	format=None,
-	doc=None,
-	no_letterhead=0,
-	language=None,
-	letterhead=None,
-	pdf_generator=None,
+	format: str | None = None,
+	doc: FrappeDocument | str | dict[str, Any] | None = None,
+	no_letterhead: str | int | None = None,
+	language: str | None = None,
+	letterhead: str | None = None,
+	pdf_generator: Literal["wkhtmltopdf", "chrome"] | None = None,
 ):
 	from frappe.utils.print_format import download_pdf as frappe_download_pdf
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -994,13 +994,20 @@ def as_base_64(content: str | bytes) -> str:
 
 @frappe.whitelist(allow_guest=True)
 def download_pdf(
-	doctype: str, name: str, format=None, doc=None, no_letterhead=0, language=None, letterhead=None
+	doctype: str,
+	name: str,
+	format=None,
+	doc=None,
+	no_letterhead=0,
+	language=None,
+	letterhead=None,
+	pdf_generator=None,
 ):
 	from frappe.utils.print_format import download_pdf as frappe_download_pdf
 
 	# Regular Frappe PDF download
 	# Sets frappe.local.response.filecontent to the PDF data
-	frappe_download_pdf(doctype, name, format, doc, no_letterhead, language, letterhead)
+	frappe_download_pdf(doctype, name, format, doc, no_letterhead, language, letterhead, pdf_generator)
 
 	# If the doctype is a Sales Invoice, try to attach the XML to the PDF
 	if doctype == "Sales Invoice":


### PR DESCRIPTION
Accept the `pdf_generator` parameter introduced in https://github.com/frappe/frappe/pull/31069 and pass it along.

This should fix problems with using the "chrome" pdf generator along with this app.

I'm also adding type hints to increase endpoint security and satisfy the linter.