### PR TITLE
fix: set custom invoice number only if available

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -213,12 +213,11 @@ class EInvoiceGenerator:
 		sales_invoice_number_field = frappe.db.get_single_value(
 			"E Invoice Settings", "sales_invoice_number_field"
 		)
-		if sales_invoice_number_field:
-			invoice_name = self.invoice.get(sales_invoice_number_field)
-		else:
-			invoice_name = self.invoice.name
 
-		self.doc.header.id = invoice_name
+		if sales_invoice_number_field and (invoice_number := self.invoice.get(sales_invoice_number_field)):
+			self.doc.header.id = invoice_number
+		else:
+			self.doc.header.id = self.invoice.name
 
 		# https://unece.org/fileadmin/DAM/trade/untdid/d16b/tred/tred1001.htm
 		if self.invoice.is_return:


### PR DESCRIPTION
The custom invoice number might not be generated until submission.
For e-invoice validation to pass during previous draft saves, we need to fall back to `doc.name` as long as the custom number is not available.
