### PR TITLE
fix: remove stripping of swiss vat endings in e-invoice

### DIFF
--- a/eu_einvoice/switzerland.py
+++ b/eu_einvoice/switzerland.py
@@ -2,7 +2,13 @@ import re
 
 
 def normalize_swiss_vat_id(vat_id: str) -> str:
-	return vat_id.strip().replace(" ", "").replace("-", "").replace(".", "")[:12].upper()
+	"""
+	### Normalizes a Swiss VAT ID
+	- remove spaces, hyphens, dots
+	- Keep suffixes like MWST, TVA, IVA.
+	- Example: 'CHE-123.456.789 MWST' becomes 'CHE123456789MWST'
+	"""
+	return vat_id.strip().replace(" ", "").replace("-", "").replace(".", "").upper()
 
 
 def is_valid_swiss_vat_id(vat_id: str) -> bool:
@@ -10,11 +16,13 @@ def is_valid_swiss_vat_id(vat_id: str) -> bool:
 	Validates a Swiss VAT ID (UID).
 	Expected formats: 'CHE-123.456.789 MWST', 'CHE123456789', etc.
 	"""
-	# 1. Clean the string: keep only 'CHE' and the 9 digits
-	# Removes dots, hyphens, spaces, and suffixes (MWST/TVA/IVA)
+
 	normalized = normalize_swiss_vat_id(vat_id)
 
-	# Check basic structure: Must start with CHE followed by exactly 9 digits
+	# Remove allowed endings: MWST, TVA, IVA if present
+	normalized = re.sub(r"(MWST|TVA|IVA)$", "", normalized)
+
+	# 1. Check basic structure: Must start with CHE followed by exactly 9 digits
 	if not re.match(r"^CHE\d{9}$", normalized):
 		return False
 

--- a/eu_einvoice/switzerland.py
+++ b/eu_einvoice/switzerland.py
@@ -5,7 +5,7 @@ def normalize_swiss_vat_id(vat_id: str) -> str:
 	"""
 	### Normalizes a Swiss VAT ID
 	- remove spaces, hyphens, dots
-	- Keep suffixes like MWST, TVA, IVA.
+	- Keep suffixes like MWST, TVA, IVA, VAT.
 	- Example: 'CHE-123.456.789 MWST' becomes 'CHE123456789MWST'
 	"""
 	return vat_id.strip().replace(" ", "").replace("-", "").replace(".", "").upper()
@@ -19,8 +19,8 @@ def is_valid_swiss_vat_id(vat_id: str) -> bool:
 
 	normalized = normalize_swiss_vat_id(vat_id)
 
-	# Remove allowed endings: MWST, TVA, IVA if present
-	normalized = re.sub(r"(MWST|TVA|IVA)$", "", normalized)
+	# Remove allowed endings: MWST, TVA, IVA, TPV if present
+	normalized = re.sub(r"(MWST|TVA|IVA|TPV)$", "", normalized)
 
 	# 1. Check basic structure: Must start with CHE followed by exactly 9 digits
 	if not re.match(r"^CHE\d{9}$", normalized):


### PR DESCRIPTION
### Business Background:

In Switzerland, the rule for the ending is simple but strict. Whether the ending is "missing" or "present" depends entirely on the tax status of the company.

1. When the ending MUST be present

- If the Swiss company is VAT-registered (meaning they have a turnover >100,000 CHF or have registered voluntarily), the ending (MWST/TVA/IVA) is legally mandatory on all invoices.
Format: CHE-116.281.710 MWST
Legal Reason: Under Art. 26 of the Swiss VAT Act, a "valid tax voucher" for input tax deduction must show the UID including the VAT suffix. If a German company invoices a Swiss company and omits the suffix, the Swiss company might technically be denied the right to "claim back" the VAT (if any was charged) or may face issues during a tax audit.

2. When the ending is allowed (and expected) to be missing
There are three specific cases where you will see the number without any ending:

- Small Businesses: Companies with a worldwide turnover of less than 100,000 CHF are not liable for VAT. They have a UID (the CHE- number) for administrative identification, but they cannot add the suffix because they aren't in the VAT register.
- Administrative Use Only: If the number is used purely for identification (e.g., in a contract, a shipping manifest, or a simple address block) and not for tax-relevant billing, the suffix is often omitted.
- Public Entities/Non-Profits: Certain government bodies or charities may have a UID but are exempt from VAT duties.

3. Special Case: Liechtenstein
If you are invoicing a company in Liechtenstein, they also use the CHE prefix (due to a treaty with Switzerland). However, Liechtenstein companies do not use the suffixes MWST/TVA/IVA. They simply use the number CHE-123.456.789.

### Meaning for the Code:

- We need to keep the allowed endings MWST/TVA/IVA if present
- We cannot enforce them, since there are valid exceptions
- Other endings should fail the validation process
