### PR TITLE
feat: add BT-120 VAT exemption reason

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -127,6 +127,7 @@ class EInvoiceGenerator:
 		self.doc = None
 		self.item_tax_rates = set()
 		self.delivery_dates = []
+		self.vat_exemption_reason_text = ""
 
 	def get_einvoice(self) -> Document | None:
 		"""Return the einvoice document as a Python object."""
@@ -135,6 +136,9 @@ class EInvoiceGenerator:
 	def create_einvoice(self):
 		"""Create the einvoice document as a Python object."""
 		self.doc = Document()
+		self.vat_exemption_reason_text = str(
+			frappe.db.get_single_value("E Invoice Settings", "vat_exemption_reason_text") or ""
+		).strip()
 
 		self._set_context()
 		self._set_header()
@@ -273,7 +277,10 @@ class EInvoiceGenerator:
 		self._set_seller_address()
 
 	def _set_seller_id(self):
-		for row in self.customer.supplier_numbers:
+		supplier_numbers = getattr(self.customer, "supplier_numbers", None)
+		if not supplier_numbers:
+			return
+		for row in supplier_numbers:
 			if row.company == self.invoice.company and row.supplier_number:
 				self.doc.trade.agreement.seller.id = row.supplier_number
 				break
@@ -486,6 +493,7 @@ class EInvoiceGenerator:
 					("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 				]
 			).upper()
+			self._set_optional_vat_exemption_reason_text(li.settlement.trade_tax)
 
 		li.settlement.monetary_summation.total_amount = flt(item.net_amount, item.precision("net_amount"))
 		self.doc.trade.items.add(li)
@@ -614,7 +622,12 @@ class EInvoiceGenerator:
 				("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 			]
 		).upper()
+		self._set_optional_vat_exemption_reason_text(trade_tax)
 		self.doc.trade.settlement.trade_tax.add(trade_tax)
+
+	def _set_optional_vat_exemption_reason_text(self, trade_tax: ApplicableTradeTax) -> None:
+		if self.vat_exemption_reason_text:
+			trade_tax.exemption_reason = self.vat_exemption_reason_text
 
 	def _add_delivery_date(self):
 		if self.delivery_dates:

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, ALYF GmbH and contributors
 # For license information, please see license.txt
 
+from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -279,6 +280,8 @@ class EInvoiceImport(Document):
 		t.basis_amount = flt_or_none(tax.basis_amount._value)
 		t.rate_applicable_percent = flt_or_none(tax.rate_applicable_percent._value)
 		t.calculated_amount = flt_or_none(tax.calculated_amount._value)
+		reason_text = tax.exemption_reason._text
+		t.vat_exemption_reason_text = str(reason_text).strip() if reason_text else None
 
 	def parse_payment_term(self, term: PaymentTerms):
 		if not term.partial_amount.children:

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -12,6 +12,8 @@
   "error_action_on_save",
   "error_action_on_submit",
   "sales_invoice_number_field",
+  "section_break_bt120",
+  "vat_exemption_reason_text",
   "section_break_yldr",
   "auto_attach_xml",
   "attach_field_for_xml_file"
@@ -74,13 +76,24 @@
    "fieldname": "sales_invoice_number_field",
    "fieldtype": "Autocomplete",
    "label": "Sales Invoice Number Field"
+  },
+  {
+   "fieldname": "section_break_bt120",
+   "fieldtype": "Section Break",
+   "label": "VAT exemption (e-invoice)"
+  },
+  {
+   "description": "If set, written to BT-120 (<code>ram:ExemptionReason</code>) on VAT breakdowns where an exemption reason code is emitted. Left unset in the XML when empty.",
+   "fieldname": "vat_exemption_reason_text",
+   "fieldtype": "Small Text",
+   "label": "Default VAT exemption reason"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-06 17:52:09.990716",
+ "modified": "2026-04-21 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Settings",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -23,6 +23,7 @@ class EInvoiceSettings(Document):
 		sales_invoice_number_field: DF.Autocomplete | None
 		validate_sales_invoice_on_save: DF.Check
 		validate_sales_invoice_on_submit: DF.Check
+		vat_exemption_reason_text: DF.SmallText | None
 	# end: auto-generated types
 
 	def before_validate(self):

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
@@ -9,6 +9,7 @@
   "basis_amount",
   "rate_applicable_percent",
   "calculated_amount",
+  "vat_exemption_reason_text",
   "tax_account"
  ],
  "fields": [
@@ -36,6 +37,12 @@
    "read_only": 1
   },
   {
+   "fieldname": "vat_exemption_reason_text",
+   "fieldtype": "Small Text",
+   "label": "VAT exemption reason",
+   "read_only": 1
+  },
+  {
    "fieldname": "tax_account",
    "fieldtype": "Link",
    "label": "Tax Account",
@@ -45,7 +52,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-26 21:18:13.837830",
+ "modified": "2026-04-21 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Trade Tax",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.py
@@ -21,6 +21,7 @@ class EInvoiceTradeTax(Document):
 		parenttype: DF.Data
 		rate_applicable_percent: DF.Percent
 		tax_account: DF.Link | None
+		vat_exemption_reason_text: DF.SmallText | None
 	# end: auto-generated types
 
 	pass

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-02-06 18:22+0053\n"
+"POT-Creation-Date: 2026-04-21 15:04+0000\n"
 "PO-Revision-Date: 2026-02-05 11:13+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -16,31 +16,28 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.13.1\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:785
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:803
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht unterstützt."
 
-#. Label of the payee_account_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
 msgstr ""
 
-#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
-#. Settings'
+#. Label of a Select field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Save"
 msgstr "Aktion bei Validierungsfehler beim Speichern"
 
-#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
-#. Settings'
+#. Label of a Select field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Submit"
 msgstr "Aktion bei Validierungsfehler beim Buchen"
 
-#. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
-#. Payment Term'
+#. Label of a Currency field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
 msgstr "Tatsächlicher Betrag"
@@ -49,117 +46,111 @@ msgstr "Tatsächlicher Betrag"
 msgid "Additional supporting document to be embedded in the e-invoice file."
 msgstr "Zusätzliches Dokument, das in die E-Rechnung eingebettet werden soll."
 
-#. Label of the agreement_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Agreement"
 msgstr "Vereinbarung"
 
-#. Label of the allowance_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Allowance Total"
 msgstr "Abschläge gesamt"
 
-#. Label of the amended_from (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Amended From"
 msgstr "Korrektur von"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:105
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:106
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr "Eine E-Rechnung mit der gleichen Rechnungs-ID und Lieferanten existiert bereits."
 
-#. Label of the attach_field_for_xml_file (Autocomplete) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Autocomplete field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Attach Field for XML File"
 msgstr "Anhangsfeld für XML-Datei"
 
-#. Label of the auto_attach_xml (Check) field in DocType 'E Invoice Settings'
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Auto-attach XML File"
 msgstr "XML-Datei automatisch anhängen"
 
-#. Label of the payee_bic (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "BIC"
 msgstr ""
 
-#. Label of the basis_amount (Currency) field in DocType 'E Invoice Trade Tax'
+#. Label of a Currency field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Basis Amount"
 msgstr "Basisbetrag"
 
-#. Label of the discount_basis_date (Date) field in DocType 'E Invoice Payment
-#. Term'
+#. Label of a Date field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Basis Date"
 msgstr "Skontofrist"
 
-#. Label of the billed_quantity (Float) field in DocType 'E Invoice Item'
+#. Label of a Float field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Billed Quantity"
 msgstr "Berechnete Menge"
 
-#. Label of the billing_period_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period"
 msgstr "Leistungszeitraum"
 
-#. Label of the billing_period_end (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period End"
 msgstr "Leistungszeitraum Ende"
 
-#. Label of the billing_period_start (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period Start"
 msgstr "Leistungszeitraum Start"
 
-#. Label of the buyer_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer"
 msgstr "Käufer"
 
-#. Label of the buyer_address_line_1 (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 1"
 msgstr "Käufer-Adresse Zeile 1"
 
-#. Label of the buyer_address_line_2 (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 2"
 msgstr "Käufer-Adresse Zeile 2"
 
-#. Label of the buyer_city (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer City"
 msgstr "Käufer-Stadt"
 
-#. Label of the buyer_country (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Country"
 msgstr "Käufer-Land"
 
-#. Label of the buyer_electronic_address (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address"
 msgstr "Elektronische Adresse des Käufers"
 
-#. Label of the buyer_electronic_address_scheme (Data) field in DocType 'E
-#. Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address Scheme"
 msgstr "Schema der elektronischen Adresse des Käufers"
 
-#. Label of the buyer_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Name"
 msgstr "Käufer-Name"
 
-#. Label of the buyer_postcode (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Postcode"
 msgstr "Käufer-Postleitzahl"
@@ -169,32 +160,30 @@ msgstr "Käufer-Postleitzahl"
 msgid "Buyer Reference"
 msgstr "Käufer-Referenz"
 
-#. Label of the calculated_amount (Currency) field in DocType 'E Invoice Trade
-#. Tax'
+#. Label of a Currency field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Calculated Amount"
 msgstr "Berechneter Betrag"
 
-#. Label of the discount_calculation_percent (Percent) field in DocType 'E
-#. Invoice Payment Term'
+#. Label of a Percent field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:834
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:830
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:848
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
-#. Label of the charge_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Charge Total"
 msgstr "Zuschläge gesamt"
 
-#. Label of the company (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr "Unternehmen"
@@ -205,7 +194,7 @@ msgstr "Unternehmen"
 msgid "Configure this if you are storing  custom invoice numbers in a field other than <code>name</code>."
 msgstr "Konfigurieren Sie dies, wenn Sie benutzerdefinierte Rechnungsnummern in einem anderen Feld als <code>name</code> speichern."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:211
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:212
 msgid "Could not validate E Invoice schematron. See Error Log for details."
 msgstr "E-Rechnung konnte nicht validiert werden. Details im Fehlerlog."
 
@@ -213,47 +202,49 @@ msgstr "E-Rechnung konnte nicht validiert werden. Details im Fehlerlog."
 msgid "Create"
 msgstr "Erstellen"
 
-#. Label of the create_item (Button) field in DocType 'E Invoice Item'
+#. Label of a Button field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Create Item"
 msgstr "Artikel erstellen"
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:93
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:434
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:437
 msgid "Create Purchase Invoice"
 msgstr "Eingangsrechnung erstellen"
 
-#. Label of the create_supplier (Button) field in DocType 'E Invoice Import'
+#. Label of a Button field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier"
 msgstr "Lieferant erstellen"
 
-#. Label of the create_supplier_address (Button) field in DocType 'E Invoice
-#. Import'
+#. Label of a Button field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier Address"
 msgstr "Lieferanten-Adresse erstellen"
 
-#. Label of the currency (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Currency"
 msgstr "Währung"
 
-#. Label of the delivery_tab (Tab Break) field in DocType 'E Invoice Import'
-#. Label of the delivery_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Small Text field in DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Default VAT exemption reason"
+msgstr ""
+
+#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Delivery"
 msgstr "Lieferung"
 
-#. Label of the section_break_mgef (Section Break) field in DocType 'E Invoice
-#. Payment Term'
+#. Label of a Section Break field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Discount"
 msgstr "Rabatt"
 
-#. Label of the document_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Document"
 msgstr "Dokument"
@@ -262,17 +253,17 @@ msgstr "Dokument"
 msgid "Download eInvoice"
 msgstr "E-Rechnung herunterladen"
 
-#. Label of the due (Date) field in DocType 'E Invoice Payment Term'
+#. Label of a Date field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Due"
 msgstr "Fällig"
 
-#. Label of the due_date (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Date"
 msgstr "Fälligkeitsdatum"
 
-#. Label of the due_payable (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Payable"
 msgstr "Fälliger Betrag"
@@ -284,12 +275,11 @@ msgstr "Fälliger Betrag"
 msgid "E Invoice Import"
 msgstr "E-Rechnungs-Import"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:650
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:653
 msgid "E Invoice Import {0} does not exist"
 msgstr "E-Rechnungs-Import {0} existiert nicht"
 
-#. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
-#. Import'
+#. Label of a Check field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:165
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
@@ -319,7 +309,7 @@ msgstr "E-Rechnungs-Einstellungen"
 msgid "E Invoice Trade Tax"
 msgstr "E-Rechnungs-Steuer"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:798
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
 msgid "E Invoice is not correct"
 msgstr "E-Rechnung ist nicht korrekt"
 
@@ -328,7 +318,7 @@ msgstr "E-Rechnung ist nicht korrekt"
 msgid "E Invoicing"
 msgstr ""
 
-#. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
+#. Label of a Attach field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
 msgstr "E-Rechnung"
@@ -354,58 +344,62 @@ msgstr "Eingebettetes Dokument"
 msgid "Error Message"
 msgstr "Fehlermeldung"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:50
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:51
 msgid "Field '{0}' does not exist on Sales Invoice doctype"
 msgstr "Feld '{0}' existiert nicht im DocType 'Sales Invoice'"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:58
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:59
 msgid "Field '{0}' must be of type 'Attach'. Current type: {1}"
 msgstr "Feld '{0}' muss vom Typ 'Anhängen' sein. Aktueller Typ: {1}"
 
-#. Label of the file_section_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "File Section"
 msgstr "Datei-Abschnitt"
 
-#. Label of the grand_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Grand Total"
 msgstr "Gesamtbetrag"
 
-#. Label of the header_section (Section Break) field in DocType 'E Invoice
-#. Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Header"
 msgstr "Kopfzeile"
 
-#. Label of the payee_iban (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "IBAN"
-msgstr ""
+msgstr "IBAN"
 
-#. Label of the id (Data) field in DocType 'E Invoice Import'
+#. Description of the 'Default VAT exemption reason' (Small Text) field in
+#. DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "If set, written to BT-120 (<code>ram:ExemptionReason</code>) on VAT breakdowns where an exemption reason code is emitted. Left unset in the XML when empty."
+msgstr "Wenn ausgefüllt, wird der Text als BT-120 (<code>ram:ExemptionReason</code>) in der Steueraufschlüsselung geschrieben, sobald ein Befreiungsgrundcode ausgegeben wird. Bleibt das Feld leer, wird BT-120 im XML nicht gesetzt."
+
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Invoice ID"
 msgstr "Rechnungs-ID"
 
-#. Label of the issue_date (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Issue Date"
 msgstr "Ausstellungsdatum"
 
-#. Label of the item (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Item"
 msgstr "Artikel"
 
-#. Label of the items (Table) field in DocType 'E Invoice Import'
-#. Label of the items_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Items"
 msgstr "Positionen"
 
-#. Label of the line_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Line Total"
 msgstr "Zeilensumme"
@@ -414,22 +408,21 @@ msgstr "Zeilensumme"
 msgid "Link to {0}"
 msgstr "Mit {0} verknüpfen"
 
-#. Label of the monetary_summation_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Monetary Summation"
 msgstr "Gesamtbeträge"
 
-#. Label of the net_rate (Currency) field in DocType 'E Invoice Item'
+#. Label of a Currency field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Net Rate"
 msgstr "Nettopreis"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:443
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:446
 msgid "No machine-readable data was found in the PDF file. You can create a regular Purchase Invoice manually instead."
 msgstr "In der PDF-Datei wurden keine maschinenlesbaren Daten gefunden. Sie können stattdessen eine reguläre Eingangsrechnung manuell erstellen."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:446
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:449
 msgid "Not an E-Invoice"
 msgstr "Keine E-Rechnung"
 
@@ -439,28 +432,26 @@ msgstr "Keine E-Rechnung"
 msgid "On submit, only for E Invoice Profile \"XRECHNUNG\""
 msgstr "Nur bei E-Rechnungs-Profil \"XRECHNUNG\" beim Buchen"
 
-#. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
-#. Term'
+#. Label of a Currency field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Partial Amount"
 msgstr "Teilbetrag"
 
-#. Label of the payment_means_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Means"
 msgstr "Zahlungsmittel"
 
-#. Label of the payment_terms (Table) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:119
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:120
 msgid "Please create or select a supplier before submitting"
 msgstr "Bitte vor dem Buchen einen Lieferanten auswählen oder erstellen."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:125
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:126
 msgid "Please map all invoice lines to an item before submitting"
 msgstr "Bitte vor dem Buchen alle Positionen einem Artikel zuordnen."
 
@@ -468,33 +459,36 @@ msgstr "Bitte vor dem Buchen alle Positionen einem Artikel zuordnen."
 msgid "Please note the validation errors of the e-invoice."
 msgstr "Bitte beachten Sie die Validierungsfehler der E-Rechnung."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:122
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:123
 msgid "Please select a company before submitting"
 msgstr "Bitte vor dem Buchen ein Unternehmen auswählen."
 
-#. Label of the product_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product"
 msgstr "Produkt"
 
-#. Label of the product_description (Small Text) field in DocType 'E Invoice
-#. Item'
+#. Label of a Small Text field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Description"
 msgstr "Produktbeschreibung"
 
-#. Label of the product_name (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Name"
 msgstr "Produktname"
 
-#. Label of the profile (Read Only) field in DocType 'E Invoice Import'
+#. Label of a Read Only field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Profile"
 msgstr "Profil"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:644
+#. Linked DocType in E Invoice Import's connections
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+msgid "Purchase Invoice"
+msgstr "Eingangsrechnung"
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:647
 msgid "Purchase Invoice {0} is already linked to E Invoice Import {1}"
 msgstr "Eingangsrechnung {0} ist bereits mit E-Rechnungs-Import {1} verknüpft"
 
@@ -503,12 +497,12 @@ msgstr "Eingangsrechnung {0} ist bereits mit E-Rechnungs-Import {1} verknüpft"
 msgid "Purchase Manager"
 msgstr ""
 
-#. Label of the purchase_order (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Purchase Order"
 msgstr "Lieferantenauftrag"
 
-#. Label of the po_detail (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Purchase Order Row"
 msgstr ""
@@ -518,101 +512,93 @@ msgstr ""
 msgid "Purchase User"
 msgstr ""
 
-#. Label of the rate_applicable_percent (Percent) field in DocType 'E Invoice
-#. Trade Tax'
+#. Label of a Percent field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Rate Applicable Percent"
 msgstr "Anwendbarer Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:670
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:673
 msgid "Row {0}"
 msgstr "Zeile {0}"
 
-#. Label of the sales_invoice_section (Section Break) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Section Break field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice"
 msgstr "Ausgangsrechnung"
 
-#. Label of the sales_invoice_number_field (Autocomplete) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Autocomplete field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice Number Field"
 msgstr "Rechnungsnummer-Feld"
 
-#. Label of the seller_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller"
 msgstr "Verkäufer"
 
-#. Label of the seller_address_line_1 (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 1"
 msgstr "Verkäufer-Adresse Zeile 1"
 
-#. Label of the seller_address_line_2 (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 2"
 msgstr "Verkäufer-Adresse Zeile 2"
 
-#. Label of the seller_city (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller City"
 msgstr "Verkäufer-Stadt"
 
-#. Label of the seller_country (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Country"
 msgstr "Verkäufer-Land"
 
-#. Label of the seller_electronic_address (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address"
 msgstr "Elektronische Adresse des Verkäufers"
 
-#. Label of the seller_electronic_address_scheme (Data) field in DocType 'E
-#. Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address Scheme"
 msgstr "Schema der elektronischen Adresse des Verkäufers"
 
-#. Label of the seller_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Name"
 msgstr "Verkäufer-Name"
 
-#. Label of the seller_postcode (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Postcode"
 msgstr "Verkäufer-Postleitzahl"
 
-#. Label of the seller_product_id (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Seller Product ID"
 msgstr "Verkäufer-Produkt-ID"
 
-#. Label of the seller_tax_id (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Tax ID"
 msgstr "Verkäufer-Steuer-ID"
 
-#. Label of the settlement_tab (Tab Break) field in DocType 'E Invoice Import'
-#. Label of the settlement_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Settlement"
 msgstr "Ausgleich"
 
-#. Label of the supplier (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
 msgstr "Lieferant"
 
-#. Label of the supplier_address (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
 msgstr "Lieferanten-Adresse"
@@ -627,60 +613,60 @@ msgstr "Lieferantenrechnungsdatei"
 msgid "System Manager"
 msgstr ""
 
-#. Label of the tax_account (Link) field in DocType 'E Invoice Trade Tax'
+#. Label of a Link field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Tax Account"
 msgstr "Steuer-Konto"
 
-#. Label of the tax_basis_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Basis Total"
 msgstr "Steuerbasis gesamt"
 
-#. Label of the tax_rate (Percent) field in DocType 'E Invoice Item'
+#. Label of a Percent field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Tax Rate"
 msgstr "Steuersatz"
 
-#. Label of the tax_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Total"
 msgstr "Steuer gesamt"
 
-#. Label of the taxes (Table) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Taxes"
 msgstr "Steuern"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:453
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:456
 msgid "The format of the uploaded file ({0}) is not supported for E-Invoices. Please upload a valid E-Invoice file or create a regular Purchase Invoice manually instead."
 msgstr "Das Format der hochgeladenen Datei ({0}) wird für E-Rechnungen nicht unterstützt. Bitte laden Sie eine gültige E-Rechnungsdatei hoch oder erstellen Sie stattdessen eine reguläre Eingangsrechnung manuell."
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:160
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:161
 msgid "The uploaded file does not contain valid XML data."
 msgstr "Die hochgeladene Datei enthält keine gültige XML-Daten."
 
-#. Label of the total_amount (Currency) field in DocType 'E Invoice Item'
+#. Label of a Currency field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Total Amount"
 msgstr "Gesamtbetrag"
 
-#. Label of the total_prepaid (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Total Prepaid"
 msgstr "Vorausbezahlt"
 
-#. Label of the uom (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "UOM"
 msgstr "Einheit"
 
-#. Label of the unit_code (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Unit Code"
 msgstr "Einheits-Code"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:456
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:459
 msgid "Unsupported file format"
 msgstr "Nicht unterstütztes Dateiformat"
 
@@ -689,31 +675,38 @@ msgstr "Nicht unterstütztes Dateiformat"
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr "Laden Sie die von Ihrem Lieferanten bereitgestellte <code>.xml</code>- oder <code>.pdf</code>-Datei hoch."
 
-#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Section Break field in DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "VAT exemption (e-invoice)"
+msgstr "Umsatzsteuerbefreiung (E-Rechnung)"
+
+#. Label of a Small Text field in DocType 'E Invoice Trade Tax'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
+msgid "VAT exemption reason"
+msgstr "Grund für Umsatzsteuerbefreiung"
+
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Save"
 msgstr "E-Rechnung beim Speichern validieren"
 
-#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Submit"
 msgstr "E-Rechnung beim Buchen validieren"
 
-#. Label of the validation_details_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Details"
 msgstr "Validierungsdetails"
 
-#. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
+#. Label of a Text field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:175
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
 msgstr "Validierungsfehler"
 
-#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
+#. Label of a Text field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:185
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Warnings"
@@ -730,19 +723,19 @@ msgstr "{0} ansehen"
 msgid "Warning Message"
 msgstr "Warnung"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:764
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:782
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:753
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:771
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr "Die Gebührenart 'Tatsächlich' wird nur in den E-Rechnungs-Profilen 'EXTENDED' und 'XRECHNUNG' unterstützt."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:741
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:759
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:776
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:794
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,38 +7,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-02-06 18:22+0053\n"
-"PO-Revision-Date: 2026-02-06 18:22+0053\n"
+"POT-Creation-Date: 2026-04-21 15:04+0000\n"
+"PO-Revision-Date: 2026-04-21 15:04+0000\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.13.1\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:785
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:803
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr ""
 
-#. Label of the payee_account_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
 msgstr ""
 
-#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
-#. Settings'
+#. Label of a Select field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Save"
 msgstr ""
 
-#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
-#. Settings'
+#. Label of a Select field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Submit"
 msgstr ""
 
-#. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
-#. Payment Term'
+#. Label of a Currency field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
 msgstr ""
@@ -47,117 +44,111 @@ msgstr ""
 msgid "Additional supporting document to be embedded in the e-invoice file."
 msgstr ""
 
-#. Label of the agreement_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Agreement"
 msgstr ""
 
-#. Label of the allowance_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Allowance Total"
 msgstr ""
 
-#. Label of the amended_from (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Amended From"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:105
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:106
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr ""
 
-#. Label of the attach_field_for_xml_file (Autocomplete) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Autocomplete field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Attach Field for XML File"
 msgstr ""
 
-#. Label of the auto_attach_xml (Check) field in DocType 'E Invoice Settings'
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Auto-attach XML File"
 msgstr ""
 
-#. Label of the payee_bic (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "BIC"
 msgstr ""
 
-#. Label of the basis_amount (Currency) field in DocType 'E Invoice Trade Tax'
+#. Label of a Currency field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Basis Amount"
 msgstr ""
 
-#. Label of the discount_basis_date (Date) field in DocType 'E Invoice Payment
-#. Term'
+#. Label of a Date field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Basis Date"
 msgstr ""
 
-#. Label of the billed_quantity (Float) field in DocType 'E Invoice Item'
+#. Label of a Float field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Billed Quantity"
 msgstr ""
 
-#. Label of the billing_period_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period"
 msgstr ""
 
-#. Label of the billing_period_end (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period End"
 msgstr ""
 
-#. Label of the billing_period_start (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period Start"
 msgstr ""
 
-#. Label of the buyer_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer"
 msgstr ""
 
-#. Label of the buyer_address_line_1 (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 1"
 msgstr ""
 
-#. Label of the buyer_address_line_2 (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 2"
 msgstr ""
 
-#. Label of the buyer_city (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer City"
 msgstr ""
 
-#. Label of the buyer_country (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Country"
 msgstr ""
 
-#. Label of the buyer_electronic_address (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address"
 msgstr ""
 
-#. Label of the buyer_electronic_address_scheme (Data) field in DocType 'E
-#. Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address Scheme"
 msgstr ""
 
-#. Label of the buyer_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Name"
 msgstr ""
 
-#. Label of the buyer_postcode (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Postcode"
 msgstr ""
@@ -167,32 +158,30 @@ msgstr ""
 msgid "Buyer Reference"
 msgstr ""
 
-#. Label of the calculated_amount (Currency) field in DocType 'E Invoice Trade
-#. Tax'
+#. Label of a Currency field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Calculated Amount"
 msgstr ""
 
-#. Label of the discount_calculation_percent (Percent) field in DocType 'E
-#. Invoice Payment Term'
+#. Label of a Percent field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:834
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:830
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:848
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
-#. Label of the charge_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Charge Total"
 msgstr ""
 
-#. Label of the company (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr ""
@@ -203,7 +192,7 @@ msgstr ""
 msgid "Configure this if you are storing  custom invoice numbers in a field other than <code>name</code>."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:211
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:212
 msgid "Could not validate E Invoice schematron. See Error Log for details."
 msgstr ""
 
@@ -211,47 +200,49 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#. Label of the create_item (Button) field in DocType 'E Invoice Item'
+#. Label of a Button field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Create Item"
 msgstr ""
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.js:93
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:434
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:437
 msgid "Create Purchase Invoice"
 msgstr ""
 
-#. Label of the create_supplier (Button) field in DocType 'E Invoice Import'
+#. Label of a Button field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier"
 msgstr ""
 
-#. Label of the create_supplier_address (Button) field in DocType 'E Invoice
-#. Import'
+#. Label of a Button field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier Address"
 msgstr ""
 
-#. Label of the currency (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Currency"
 msgstr ""
 
-#. Label of the delivery_tab (Tab Break) field in DocType 'E Invoice Import'
-#. Label of the delivery_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Small Text field in DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Default VAT exemption reason"
+msgstr ""
+
+#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Delivery"
 msgstr ""
 
-#. Label of the section_break_mgef (Section Break) field in DocType 'E Invoice
-#. Payment Term'
+#. Label of a Section Break field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Discount"
 msgstr ""
 
-#. Label of the document_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Document"
 msgstr ""
@@ -260,17 +251,17 @@ msgstr ""
 msgid "Download eInvoice"
 msgstr ""
 
-#. Label of the due (Date) field in DocType 'E Invoice Payment Term'
+#. Label of a Date field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Due"
 msgstr ""
 
-#. Label of the due_date (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Date"
 msgstr ""
 
-#. Label of the due_payable (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Payable"
 msgstr ""
@@ -282,12 +273,11 @@ msgstr ""
 msgid "E Invoice Import"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:650
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:653
 msgid "E Invoice Import {0} does not exist"
 msgstr ""
 
-#. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
-#. Import'
+#. Label of a Check field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:165
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
@@ -317,7 +307,7 @@ msgstr ""
 msgid "E Invoice Trade Tax"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:798
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
 msgid "E Invoice is not correct"
 msgstr ""
 
@@ -326,7 +316,7 @@ msgstr ""
 msgid "E Invoicing"
 msgstr ""
 
-#. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
+#. Label of a Attach field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
 msgstr ""
@@ -353,58 +343,62 @@ msgstr ""
 msgid "Error Message"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:50
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:51
 msgid "Field '{0}' does not exist on Sales Invoice doctype"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:58
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:59
 msgid "Field '{0}' must be of type 'Attach'. Current type: {1}"
 msgstr ""
 
-#. Label of the file_section_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "File Section"
 msgstr ""
 
-#. Label of the grand_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Grand Total"
 msgstr ""
 
-#. Label of the header_section (Section Break) field in DocType 'E Invoice
-#. Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Header"
 msgstr ""
 
-#. Label of the payee_iban (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "IBAN"
 msgstr ""
 
-#. Label of the id (Data) field in DocType 'E Invoice Import'
+#. Description of the 'Default VAT exemption reason' (Small Text) field in
+#. DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "If set, written to BT-120 (<code>ram:ExemptionReason</code>) on VAT breakdowns where an exemption reason code is emitted. Left unset in the XML when empty."
+msgstr ""
+
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Invoice ID"
 msgstr ""
 
-#. Label of the issue_date (Date) field in DocType 'E Invoice Import'
+#. Label of a Date field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Issue Date"
 msgstr ""
 
-#. Label of the item (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Item"
 msgstr ""
 
-#. Label of the items (Table) field in DocType 'E Invoice Import'
-#. Label of the items_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Items"
 msgstr ""
 
-#. Label of the line_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Line Total"
 msgstr ""
@@ -413,22 +407,21 @@ msgstr ""
 msgid "Link to {0}"
 msgstr ""
 
-#. Label of the monetary_summation_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Monetary Summation"
 msgstr ""
 
-#. Label of the net_rate (Currency) field in DocType 'E Invoice Item'
+#. Label of a Currency field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Net Rate"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:443
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:446
 msgid "No machine-readable data was found in the PDF file. You can create a regular Purchase Invoice manually instead."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:446
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:449
 msgid "Not an E-Invoice"
 msgstr ""
 
@@ -438,28 +431,26 @@ msgstr ""
 msgid "On submit, only for E Invoice Profile \"XRECHNUNG\""
 msgstr ""
 
-#. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
-#. Term'
+#. Label of a Currency field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Partial Amount"
 msgstr ""
 
-#. Label of the payment_means_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Means"
 msgstr ""
 
-#. Label of the payment_terms (Table) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Terms"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:119
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:120
 msgid "Please create or select a supplier before submitting"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:125
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:126
 msgid "Please map all invoice lines to an item before submitting"
 msgstr ""
 
@@ -467,33 +458,36 @@ msgstr ""
 msgid "Please note the validation errors of the e-invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:122
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:123
 msgid "Please select a company before submitting"
 msgstr ""
 
-#. Label of the product_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product"
 msgstr ""
 
-#. Label of the product_description (Small Text) field in DocType 'E Invoice
-#. Item'
+#. Label of a Small Text field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Description"
 msgstr ""
 
-#. Label of the product_name (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Name"
 msgstr ""
 
-#. Label of the profile (Read Only) field in DocType 'E Invoice Import'
+#. Label of a Read Only field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Profile"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:644
+#. Linked DocType in E Invoice Import's connections
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+msgid "Purchase Invoice"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:647
 msgid "Purchase Invoice {0} is already linked to E Invoice Import {1}"
 msgstr ""
 
@@ -502,12 +496,12 @@ msgstr ""
 msgid "Purchase Manager"
 msgstr ""
 
-#. Label of the purchase_order (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Purchase Order"
 msgstr ""
 
-#. Label of the po_detail (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Purchase Order Row"
 msgstr ""
@@ -517,101 +511,93 @@ msgstr ""
 msgid "Purchase User"
 msgstr ""
 
-#. Label of the rate_applicable_percent (Percent) field in DocType 'E Invoice
-#. Trade Tax'
+#. Label of a Percent field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Rate Applicable Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:670
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:673
 msgid "Row {0}"
 msgstr ""
 
-#. Label of the sales_invoice_section (Section Break) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Section Break field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice"
 msgstr ""
 
-#. Label of the sales_invoice_number_field (Autocomplete) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Autocomplete field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice Number Field"
 msgstr ""
 
-#. Label of the seller_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller"
 msgstr ""
 
-#. Label of the seller_address_line_1 (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 1"
 msgstr ""
 
-#. Label of the seller_address_line_2 (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 2"
 msgstr ""
 
-#. Label of the seller_city (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller City"
 msgstr ""
 
-#. Label of the seller_country (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Country"
 msgstr ""
 
-#. Label of the seller_electronic_address (Data) field in DocType 'E Invoice
-#. Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address"
 msgstr ""
 
-#. Label of the seller_electronic_address_scheme (Data) field in DocType 'E
-#. Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address Scheme"
 msgstr ""
 
-#. Label of the seller_name (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Name"
 msgstr ""
 
-#. Label of the seller_postcode (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Postcode"
 msgstr ""
 
-#. Label of the seller_product_id (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Seller Product ID"
 msgstr ""
 
-#. Label of the seller_tax_id (Data) field in DocType 'E Invoice Import'
+#. Label of a Data field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Tax ID"
 msgstr ""
 
-#. Label of the settlement_tab (Tab Break) field in DocType 'E Invoice Import'
-#. Label of the settlement_section (Section Break) field in DocType 'E Invoice
-#. Item'
+#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Settlement"
 msgstr ""
 
-#. Label of the supplier (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
 msgstr ""
 
-#. Label of the supplier_address (Link) field in DocType 'E Invoice Import'
+#. Label of a Link field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
 msgstr ""
@@ -626,60 +612,60 @@ msgstr ""
 msgid "System Manager"
 msgstr ""
 
-#. Label of the tax_account (Link) field in DocType 'E Invoice Trade Tax'
+#. Label of a Link field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Tax Account"
 msgstr ""
 
-#. Label of the tax_basis_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Basis Total"
 msgstr ""
 
-#. Label of the tax_rate (Percent) field in DocType 'E Invoice Item'
+#. Label of a Percent field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Tax Rate"
 msgstr ""
 
-#. Label of the tax_total (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Total"
 msgstr ""
 
-#. Label of the taxes (Table) field in DocType 'E Invoice Import'
+#. Label of a Table field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Taxes"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:453
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:456
 msgid "The format of the uploaded file ({0}) is not supported for E-Invoices. Please upload a valid E-Invoice file or create a regular Purchase Invoice manually instead."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:160
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:161
 msgid "The uploaded file does not contain valid XML data."
 msgstr ""
 
-#. Label of the total_amount (Currency) field in DocType 'E Invoice Item'
+#. Label of a Currency field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Total Amount"
 msgstr ""
 
-#. Label of the total_prepaid (Currency) field in DocType 'E Invoice Import'
+#. Label of a Currency field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Total Prepaid"
 msgstr ""
 
-#. Label of the uom (Link) field in DocType 'E Invoice Item'
+#. Label of a Link field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "UOM"
 msgstr ""
 
-#. Label of the unit_code (Data) field in DocType 'E Invoice Item'
+#. Label of a Data field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Unit Code"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:456
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:459
 msgid "Unsupported file format"
 msgstr ""
 
@@ -688,31 +674,38 @@ msgstr ""
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr ""
 
-#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Section Break field in DocType 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "VAT exemption (e-invoice)"
+msgstr ""
+
+#. Label of a Small Text field in DocType 'E Invoice Trade Tax'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
+msgid "VAT exemption reason"
+msgstr ""
+
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Save"
 msgstr ""
 
-#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
-#. Invoice Settings'
+#. Label of a Check field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Submit"
 msgstr ""
 
-#. Label of the validation_details_section (Section Break) field in DocType 'E
-#. Invoice Import'
+#. Label of a Section Break field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Details"
 msgstr ""
 
-#. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
+#. Label of a Text field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:175
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
 msgstr ""
 
-#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
+#. Label of a Text field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:185
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Warnings"
@@ -730,19 +723,19 @@ msgstr ""
 msgid "Warning Message"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:764
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:782
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:753
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:771
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:741
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:759
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:776
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:794
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 


### PR DESCRIPTION
Adds a BT-120 textfield for the VAT exemption reason to the E-Invoice Settings: https://github.com/alyf-de/eu_einvoice/issues/183