### PR TITLE
feat: implement XML attachment file naming functionality

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -47,8 +47,12 @@ vat_exemption_reason_codes = CommonCodeRetriever(["urn:xoev-de:kosit:codeliste:v
 
 @frappe.whitelist()
 def download_xrechnung(invoice_id: str):
-	frappe.local.response.filename = f"{invoice_id}.xml"
-	frappe.local.response.filecontent = get_einvoice(invoice_id)
+	invoice = frappe.get_doc("Sales Invoice", invoice_id)
+	invoice.check_permission("read")
+	settings = frappe.get_cached_doc("E Invoice Settings")
+	base_name = get_xml_attachment_file_base_name(invoice, settings.auto_name_format_for_xml_file)
+	frappe.local.response.filename = f"{base_name}.xml"
+	frappe.local.response.filecontent = get_einvoice(invoice)
 	frappe.local.response.type = "download"
 
 

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -15,8 +15,10 @@ from drafthorse.models.references import AdditionalReferencedDocument
 from drafthorse.models.trade import LogisticsServiceCharge
 from drafthorse.models.tradelines import LineItem
 from frappe import _
-from frappe.core.doctype.file.utils import find_file_by_url
+from frappe.core.doctype.file.utils import find_file_by_url, get_safe_file_name
 from frappe.core.utils import html2text
+from frappe.model.naming import parse_naming_series
+from frappe.utils import cstr
 from frappe.utils.data import date_diff, flt, getdate, to_markdown
 
 from eu_einvoice.common_codes import CommonCodeRetriever
@@ -919,7 +921,9 @@ def _attach_xml_file(doc: SalesInvoice, xml_content: bytes, field_name: str | No
 			)
 			return
 
-	file_name = f"{doc.name}.xml".replace("/", "-")
+	settings = frappe.get_cached_doc("E Invoice Settings")
+	base_name = get_xml_attachment_file_base_name(doc, settings.auto_name_format_for_xml_file)
+	file_name = f"{base_name}.xml"
 
 	# Create new File document
 	file_doc = frappe.new_doc("File")
@@ -1142,3 +1146,46 @@ def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 
 	xml_bytes = get_einvoice(invoice_id)
 	return attach_xml(pdf_data, xml_bytes, level)
+
+
+# Naming series treats a dot-separated part that *starts with* ``#`` as the numeric
+# counter (see :func:`frappe.model.naming.parse_naming_series`). XML filenames must
+# not touch **Series**, so each segment is passed through ``str.lstrip("#")`` before
+# parsing-counter-shaped parts become empty and are skipped, without stripping ``#``
+# elsewhere in a segment before :func:`~frappe.core.doctype.file.utils.get_safe_file_name`.
+
+
+def get_xml_attachment_file_base_name(doc, pattern: str | None) -> str:
+	"""Return the file base name without ``.xml``.
+
+	The result is passed through :func:`~frappe.core.doctype.file.utils.get_safe_file_name`
+	(same rules as **File** attachments: ``/``, ``\\``, ``%``, ``?``, ``#`` → ``_``).
+
+	* **Empty** pattern → ``doc.name`` (same as before configurable naming).
+	* Otherwise → split the pattern on ``.`` like a naming series, remove a **leading**
+	  run of ``#`` from each segment (same edge as counter parts in
+	  :func:`frappe.model.naming.parse_naming_series`), then parse the segments with
+	  ``parse_naming_series`` (``MM``, ``YYYY``, ``{fieldname}``, literals, etc.).
+
+	On failure, logs an error and falls back to ``doc.name``.
+	"""
+	pattern = cstr(pattern or "").strip()
+	if not pattern:
+		return get_safe_file_name(cstr(doc.name))
+
+	parts = [p.lstrip("#") for p in pattern.split(".")]
+	try:
+		base = parse_naming_series(parts, doc=doc)
+	except Exception:
+		frappe.log_error(
+			title=_("E Invoice XML file name pattern failed"),
+			message=frappe.get_traceback(),
+			reference_doctype=getattr(doc, "doctype", None),
+			reference_name=getattr(doc, "name", None),
+		)
+		return get_safe_file_name(cstr(doc.name))
+
+	base = cstr(base).strip()
+	if not base:
+		return get_safe_file_name(cstr(doc.name))
+	return get_safe_file_name(base)

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -48,11 +48,9 @@ vat_exemption_reason_codes = CommonCodeRetriever(["urn:xoev-de:kosit:codeliste:v
 @frappe.whitelist()
 def download_xrechnung(invoice_id: str):
 	invoice = frappe.get_doc("Sales Invoice", invoice_id)
-	invoice.check_permission("read")
-	settings = frappe.get_cached_doc("E Invoice Settings")
-	base_name = get_xml_attachment_file_base_name(invoice, settings.auto_name_format_for_xml_file)
-	frappe.local.response.filename = f"{base_name}.xml"
+	base_name = get_xml_attachment_file_base_name(invoice)
 	frappe.local.response.filecontent = get_einvoice(invoice)
+	frappe.local.response.filename = f"{base_name}.xml"
 	frappe.local.response.type = "download"
 
 
@@ -925,8 +923,7 @@ def _attach_xml_file(doc: SalesInvoice, xml_content: bytes, field_name: str | No
 			)
 			return
 
-	settings = frappe.get_cached_doc("E Invoice Settings")
-	base_name = get_xml_attachment_file_base_name(doc, settings.auto_name_format_for_xml_file)
+	base_name = get_xml_attachment_file_base_name(doc)
 	file_name = f"{base_name}.xml"
 
 	# Create new File document
@@ -1152,44 +1149,33 @@ def attach_xml_to_pdf(invoice_id: str, pdf_data: bytes) -> bytes:
 	return attach_xml(pdf_data, xml_bytes, level)
 
 
-# Naming series treats a dot-separated part that *starts with* ``#`` as the numeric
-# counter (see :func:`frappe.model.naming.parse_naming_series`). XML filenames must
-# not touch **Series**, so each segment is passed through ``str.lstrip("#")`` before
-# parsing-counter-shaped parts become empty and are skipped, without stripping ``#``
-# elsewhere in a segment before :func:`~frappe.core.doctype.file.utils.get_safe_file_name`.
+def get_xml_attachment_file_base_name(doc, *, pattern: str | None = None) -> str:
+	"""Filename stem (no `.xml`) for the downloadable XML.
 
-
-def get_xml_attachment_file_base_name(doc, pattern: str | None) -> str:
-	"""Return the file base name without ``.xml``.
-
-	The result is passed through :func:`~frappe.core.doctype.file.utils.get_safe_file_name`
-	(same rules as **File** attachments: ``/``, ``\\``, ``%``, ``?``, ``#`` → ``_``).
-
-	* **Empty** pattern → ``doc.name`` (same as before configurable naming).
-	* Otherwise → split the pattern on ``.`` like a naming series, remove a **leading**
-	  run of ``#`` from each segment (same edge as counter parts in
-	  :func:`frappe.model.naming.parse_naming_series`), then parse the segments with
-	  ``parse_naming_series`` (``MM``, ``YYYY``, ``{fieldname}``, literals, etc.).
-
-	On failure, logs an error and falls back to ``doc.name``.
+	Uses *pattern* when given, otherwise reads *Auto name format for XML file*
+	from **E Invoice Settings**. Falls back to `doc.name` when the pattern is
+	empty or fails to resolve. Result is sanitized via `get_safe_file_name`
+	(same rules as **File** attachments).
 	"""
-	pattern = cstr(pattern or "").strip()
-	if not pattern:
-		return get_safe_file_name(cstr(doc.name))
+	if pattern is None:
+		pattern = frappe.get_single_value("E Invoice Settings", "auto_name_format_for_xml_file")
+	pattern = cstr(pattern).strip()
+	if pattern:
+		try:
+			base = parse_naming_series(pattern, doc=doc, number_generator=_no_series_counter).strip()
+		except Exception:
+			frappe.log_error(
+				title=_("E Invoice XML file name pattern failed"),
+				message=frappe.get_traceback(),
+				reference_doctype=doc.doctype,
+				reference_name=doc.name,
+			)
+			base = ""
+		if base:
+			return get_safe_file_name(base)
+	return get_safe_file_name(doc.name)
 
-	parts = [p.lstrip("#") for p in pattern.split(".")]
-	try:
-		base = parse_naming_series(parts, doc=doc)
-	except Exception:
-		frappe.log_error(
-			title=_("E Invoice XML file name pattern failed"),
-			message=frappe.get_traceback(),
-			reference_doctype=getattr(doc, "doctype", None),
-			reference_name=getattr(doc, "name", None),
-		)
-		return get_safe_file_name(cstr(doc.name))
 
-	base = cstr(base).strip()
-	if not base:
-		return get_safe_file_name(cstr(doc.name))
-	return get_safe_file_name(base)
+def _no_series_counter(_key: str, _digits: int) -> str:
+	"""Disable the series counter so XML naming has no DB side effects."""
+	return ""

--- a/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -7,37 +9,50 @@ from eu_einvoice.european_e_invoice.custom.sales_invoice import (
 
 
 class TestXmlAttachmentNaming(FrappeTestCase):
+	def test_auto_name_format_from_e_invoice_settings(self):
+		doc = frappe._dict(name="SINV-00001", po_no="PO-42", doctype="Sales Invoice")
+		field = "auto_name_format_for_xml_file"
+		pattern = "XMLSTEM.-.{po_no}"
+		real_gsv = frappe.get_single_value
+
+		def get_single_value(doctype, fname, cache=True):
+			if doctype == "E Invoice Settings" and fname == field:
+				return pattern
+			return real_gsv(doctype, fname, cache=cache)
+
+		with patch.object(frappe, "get_single_value", side_effect=get_single_value):
+			self.assertEqual(get_xml_attachment_file_base_name(doc), "XMLSTEM-PO-42")
+
 	def test_empty_or_whitespace_uses_doc_name(self):
 		doc = frappe._dict(name="SINV/00001", doctype="Sales Invoice")
-		self.assertEqual(get_xml_attachment_file_base_name(doc, None), "SINV_00001")
-		self.assertEqual(get_xml_attachment_file_base_name(doc, ""), "SINV_00001")
-		self.assertEqual(get_xml_attachment_file_base_name(doc, "   "), "SINV_00001")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, pattern=""), "SINV_00001")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, pattern="   "), "SINV_00001")
 
 	def test_dot_separated_pattern_with_field(self):
 		doc = frappe._dict(name="SINV-00001", po_no="PO-1", doctype="Sales Invoice")
-		base = get_xml_attachment_file_base_name(doc, "EXAMPLE.-.{po_no}")
+		base = get_xml_attachment_file_base_name(doc, pattern="EXAMPLE.-.{po_no}")
 		self.assertEqual(base, "EXAMPLE-PO-1")
 
 	def test_dot_separated_inv_field_end(self):
 		doc = frappe._dict(name="SINV-00001", po_no="X-9", doctype="Sales Invoice")
-		base = get_xml_attachment_file_base_name(doc, "INV.-.{po_no}.-.END")
+		base = get_xml_attachment_file_base_name(doc, pattern="INV.-.{po_no}.-.END")
 		self.assertEqual(base, "INV-X-9-END")
 
 	def test_leading_hashes_stripped_per_part_avoids_series_counter(self):
 		doc = frappe._dict(name="SINV-00001", po_no="PO-1", doctype="Sales Invoice")
-		base = get_xml_attachment_file_base_name(doc, "EXAMPLE.-.{po_no}.#####")
+		base = get_xml_attachment_file_base_name(doc, pattern="EXAMPLE.-.{po_no}.#####")
 		self.assertEqual(base, "EXAMPLE-PO-1")
 
 	def test_hash_in_literal_sanitized_like_file_utils(self):
 		doc = frappe._dict(name="SINV-00001", doctype="Sales Invoice")
-		base = get_xml_attachment_file_base_name(doc, "INV#X")
+		base = get_xml_attachment_file_base_name(doc, pattern="INV#X")
 		self.assertEqual(base, "INV_X")
 
 	def test_only_hash_segments_falls_back_to_doc_name(self):
 		doc = frappe._dict(name="SINV-00001", doctype="Sales Invoice")
-		self.assertEqual(get_xml_attachment_file_base_name(doc, "#####"), "SINV-00001")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, pattern="#####"), "SINV-00001")
 
 	def test_slash_in_resolved_base_is_sanitized(self):
 		doc = frappe._dict(name="SINV-00001", po_no="A/B", doctype="Sales Invoice")
-		base = get_xml_attachment_file_base_name(doc, "{po_no}")
+		base = get_xml_attachment_file_base_name(doc, pattern="{po_no}")
 		self.assertEqual(base, "A_B")

--- a/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
@@ -1,0 +1,43 @@
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from eu_einvoice.european_e_invoice.custom.sales_invoice import (
+	get_xml_attachment_file_base_name,
+)
+
+
+class TestXmlAttachmentNaming(FrappeTestCase):
+	def test_empty_or_whitespace_uses_doc_name(self):
+		doc = frappe._dict(name="SINV/00001", doctype="Sales Invoice")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, None), "SINV_00001")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, ""), "SINV_00001")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, "   "), "SINV_00001")
+
+	def test_dot_separated_pattern_with_field(self):
+		doc = frappe._dict(name="SINV-00001", po_no="PO-1", doctype="Sales Invoice")
+		base = get_xml_attachment_file_base_name(doc, "EXAMPLE.-.{po_no}")
+		self.assertEqual(base, "EXAMPLE-PO-1")
+
+	def test_dot_separated_inv_field_end(self):
+		doc = frappe._dict(name="SINV-00001", po_no="X-9", doctype="Sales Invoice")
+		base = get_xml_attachment_file_base_name(doc, "INV.-.{po_no}.-.END")
+		self.assertEqual(base, "INV-X-9-END")
+
+	def test_leading_hashes_stripped_per_part_avoids_series_counter(self):
+		doc = frappe._dict(name="SINV-00001", po_no="PO-1", doctype="Sales Invoice")
+		base = get_xml_attachment_file_base_name(doc, "EXAMPLE.-.{po_no}.#####")
+		self.assertEqual(base, "EXAMPLE-PO-1")
+
+	def test_hash_in_literal_sanitized_like_file_utils(self):
+		doc = frappe._dict(name="SINV-00001", doctype="Sales Invoice")
+		base = get_xml_attachment_file_base_name(doc, "INV#X")
+		self.assertEqual(base, "INV_X")
+
+	def test_only_hash_segments_falls_back_to_doc_name(self):
+		doc = frappe._dict(name="SINV-00001", doctype="Sales Invoice")
+		self.assertEqual(get_xml_attachment_file_base_name(doc, "#####"), "SINV-00001")
+
+	def test_slash_in_resolved_base_is_sanitized(self):
+		doc = frappe._dict(name="SINV-00001", po_no="A/B", doctype="Sales Invoice")
+		base = get_xml_attachment_file_base_name(doc, "{po_no}")
+		self.assertEqual(base, "A_B")

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -15,10 +15,10 @@
   "section_break_bt120",
   "vat_exemption_reason_text",
   "section_break_yldr",
-  "auto_attach_xml",
-  "attach_field_for_xml_file",
+  "auto_name_format_for_xml_file",
   "column_break_vlzj",
-  "auto_name_format_for_xml_file"
+  "auto_attach_xml",
+  "attach_field_for_xml_file"
  ],
  "fields": [
   {
@@ -57,8 +57,10 @@
    "options": "\nWarning Message\nError Message"
   },
   {
+   "bold": 1,
    "fieldname": "section_break_yldr",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "XML Settings"
   },
   {
    "default": "0",
@@ -84,7 +86,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.auto_attach_xml",
    "description": "Pattern for the <b>file name</b> of the XML.  <b>.xml</b> is appended automatically. Leave <b>empty</b> to use the document <b>name</b> (Sales Invoice ID). In case of an error, the document <b>name</b> is used as fallback.\n<br><br>Segments use a <b>dot</b> (<b>.</b>) between literal text and dynamic parts. Example:<br><b>EXAMPLE-.MM.-.{po_no}.-.YYYY</b><ul><li><b>Dates</b>: <b>DD</b>, <b>MM</b>, <b>YYYY</b>, <b>YY</b>, <b>WW</b>, <b>timestamp</b></li><li><b>Fields</b>: <b>Sales Invoice</b> field names in braces, e.g. <b>{po_no}</b></li><li>Other segments are treated as literal text.</li></ul>",
    "fieldname": "auto_name_format_for_xml_file",
    "fieldtype": "Data",
@@ -106,7 +107,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-24 17:39:42.358057",
+ "modified": "2026-05-08 11:55:24.180676",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Settings",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
@@ -16,7 +16,9 @@
   "vat_exemption_reason_text",
   "section_break_yldr",
   "auto_attach_xml",
-  "attach_field_for_xml_file"
+  "attach_field_for_xml_file",
+  "column_break_vlzj",
+  "auto_name_format_for_xml_file"
  ],
  "fields": [
   {
@@ -78,6 +80,17 @@
    "label": "Sales Invoice Number Field"
   },
   {
+   "fieldname": "column_break_vlzj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.auto_attach_xml",
+   "description": "Pattern for the <b>file name</b> of the XML.  <b>.xml</b> is appended automatically. Leave <b>empty</b> to use the document <b>name</b> (Sales Invoice ID). In case of an error, the document <b>name</b> is used as fallback.\n<br><br>Segments use a <b>dot</b> (<b>.</b>) between literal text and dynamic parts. Example:<br><b>EXAMPLE-.MM.-.{po_no}.-.YYYY</b><ul><li><b>Dates</b>: <b>DD</b>, <b>MM</b>, <b>YYYY</b>, <b>YY</b>, <b>WW</b>, <b>timestamp</b></li><li><b>Fields</b>: <b>Sales Invoice</b> field names in braces, e.g. <b>{po_no}</b></li><li>Other segments are treated as literal text.</li></ul>",
+   "fieldname": "auto_name_format_for_xml_file",
+   "fieldtype": "Data",
+   "label": "Auto Name Format for XML File"
+  },
+  {
    "fieldname": "section_break_bt120",
    "fieldtype": "Section Break",
    "label": "VAT exemption (e-invoice)"
@@ -93,7 +106,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-21 12:00:00.000000",
+ "modified": "2026-04-24 17:39:42.358057",
  "modified_by": "Administrator",
  "module": "European e-Invoice",
  "name": "E Invoice Settings",

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -18,6 +18,7 @@ class EInvoiceSettings(Document):
 
 		attach_field_for_xml_file: DF.Autocomplete | None
 		auto_attach_xml: DF.Check
+		auto_name_format_for_xml_file: DF.Data | None
 		error_action_on_save: DF.Literal["", "Warning Message", "Error Message"]
 		error_action_on_submit: DF.Literal["", "Warning Message", "Error Message"]
 		sales_invoice_number_field: DF.Autocomplete | None

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-04-21 15:04+0000\n"
+"POT-Creation-Date: 2026-04-28 15:18+0053\n"
 "PO-Revision-Date: 2026-02-05 11:13+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -16,28 +16,31 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:803
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:805
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht unterstützt."
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_account_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
 msgstr ""
 
-#. Label of a Select field in DocType 'E Invoice Settings'
+#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Save"
 msgstr "Aktion bei Validierungsfehler beim Speichern"
 
-#. Label of a Select field in DocType 'E Invoice Settings'
+#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Submit"
 msgstr "Aktion bei Validierungsfehler beim Buchen"
 
-#. Label of a Currency field in DocType 'E Invoice Payment Term'
+#. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
+#. Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
 msgstr "Tatsächlicher Betrag"
@@ -46,17 +49,18 @@ msgstr "Tatsächlicher Betrag"
 msgid "Additional supporting document to be embedded in the e-invoice file."
 msgstr "Zusätzliches Dokument, das in die E-Rechnung eingebettet werden soll."
 
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the agreement_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Agreement"
 msgstr "Vereinbarung"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the allowance_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Allowance Total"
 msgstr "Abschläge gesamt"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the amended_from (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Amended From"
 msgstr "Korrektur von"
@@ -65,92 +69,103 @@ msgstr "Korrektur von"
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr "Eine E-Rechnung mit der gleichen Rechnungs-ID und Lieferanten existiert bereits."
 
-#. Label of a Autocomplete field in DocType 'E Invoice Settings'
+#. Label of the attach_field_for_xml_file (Autocomplete) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Attach Field for XML File"
 msgstr "Anhangsfeld für XML-Datei"
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the auto_name_format_for_xml_file (Data) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Auto Name Format for XML File"
+msgstr "Namensmuster für die XML-Datei"
+
+#. Label of the auto_attach_xml (Check) field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Auto-attach XML File"
 msgstr "XML-Datei automatisch anhängen"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_bic (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "BIC"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Trade Tax'
+#. Label of the basis_amount (Currency) field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Basis Amount"
 msgstr "Basisbetrag"
 
-#. Label of a Date field in DocType 'E Invoice Payment Term'
+#. Label of the discount_basis_date (Date) field in DocType 'E Invoice Payment
+#. Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Basis Date"
 msgstr "Skontofrist"
 
-#. Label of a Float field in DocType 'E Invoice Item'
+#. Label of the billed_quantity (Float) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Billed Quantity"
 msgstr "Berechnete Menge"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the billing_period_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period"
 msgstr "Leistungszeitraum"
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the billing_period_end (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period End"
 msgstr "Leistungszeitraum Ende"
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the billing_period_start (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period Start"
 msgstr "Leistungszeitraum Start"
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the buyer_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer"
 msgstr "Käufer"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_address_line_1 (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 1"
 msgstr "Käufer-Adresse Zeile 1"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_address_line_2 (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 2"
 msgstr "Käufer-Adresse Zeile 2"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_city (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer City"
 msgstr "Käufer-Stadt"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the buyer_country (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Country"
 msgstr "Käufer-Land"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_electronic_address (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address"
 msgstr "Elektronische Adresse des Käufers"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_electronic_address_scheme (Data) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address Scheme"
 msgstr "Schema der elektronischen Adresse des Käufers"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Name"
 msgstr "Käufer-Name"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_postcode (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Postcode"
 msgstr "Käufer-Postleitzahl"
@@ -160,30 +175,42 @@ msgstr "Käufer-Postleitzahl"
 msgid "Buyer Reference"
 msgstr "Käufer-Referenz"
 
-#. Label of a Currency field in DocType 'E Invoice Trade Tax'
+#. Label of the calculated_amount (Currency) field in DocType 'E Invoice Trade
+#. Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Calculated Amount"
 msgstr "Berechneter Betrag"
 
-#. Label of a Percent field in DocType 'E Invoice Payment Term'
+#. Label of the discount_calculation_percent (Percent) field in DocType 'E
+#. Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:834
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:836
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:848
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:850
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the charge_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Charge Total"
 msgstr "Zuschläge gesamt"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Code List"
+msgstr ""
+
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Common Code"
+msgstr ""
+
+#. Label of the company (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr "Unternehmen"
@@ -202,7 +229,7 @@ msgstr "E-Rechnung konnte nicht validiert werden. Details im Fehlerlog."
 msgid "Create"
 msgstr "Erstellen"
 
-#. Label of a Button field in DocType 'E Invoice Item'
+#. Label of the create_item (Button) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Create Item"
 msgstr "Artikel erstellen"
@@ -212,66 +239,77 @@ msgstr "Artikel erstellen"
 msgid "Create Purchase Invoice"
 msgstr "Eingangsrechnung erstellen"
 
-#. Label of a Button field in DocType 'E Invoice Import'
+#. Label of the create_supplier (Button) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier"
 msgstr "Lieferant erstellen"
 
-#. Label of a Button field in DocType 'E Invoice Import'
+#. Label of the create_supplier_address (Button) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier Address"
 msgstr "Lieferanten-Adresse erstellen"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the currency (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Currency"
 msgstr "Währung"
 
-#. Label of a Small Text field in DocType 'E Invoice Settings'
+#. Label of the vat_exemption_reason_text (Small Text) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Default VAT exemption reason"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the delivery_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of the delivery_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Delivery"
 msgstr "Lieferung"
 
-#. Label of a Section Break field in DocType 'E Invoice Payment Term'
+#. Label of the section_break_mgef (Section Break) field in DocType 'E Invoice
+#. Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Discount"
 msgstr "Rabatt"
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the document_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Document"
 msgstr "Dokument"
+
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Documentation"
+msgstr ""
 
 #: eu_einvoice/european_e_invoice/custom/sales_invoice.js:14
 msgid "Download eInvoice"
 msgstr "E-Rechnung herunterladen"
 
-#. Label of a Date field in DocType 'E Invoice Payment Term'
+#. Label of the due (Date) field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Due"
 msgstr "Fällig"
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the due_date (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Date"
 msgstr "Fälligkeitsdatum"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the due_payable (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Payable"
 msgstr "Fälliger Betrag"
 
 #. Name of a DocType
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/custom_fields.py:19
 #: eu_einvoice/european_e_invoice/custom/purchase_order.js:5
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "E Invoice Import"
 msgstr "E-Rechnungs-Import"
 
@@ -279,7 +317,8 @@ msgstr "E-Rechnungs-Import"
 msgid "E Invoice Import {0} does not exist"
 msgstr "E-Rechnungs-Import {0} existiert nicht"
 
-#. Label of a Check field in DocType 'E Invoice Import'
+#. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/custom_fields.py:165
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
@@ -300,7 +339,9 @@ msgid "E Invoice Profile"
 msgstr "E-Rechnungs-Profil"
 
 #. Name of a DocType
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "E Invoice Settings"
 msgstr "E-Rechnungs-Einstellungen"
 
@@ -309,7 +350,11 @@ msgstr "E-Rechnungs-Einstellungen"
 msgid "E Invoice Trade Tax"
 msgstr "E-Rechnungs-Steuer"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1181
+msgid "E Invoice XML file name pattern failed"
+msgstr "Namensmuster für E-Rechnungs-XML-Datei fehlgeschlagen"
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:818
 msgid "E Invoice is not correct"
 msgstr "E-Rechnung ist nicht korrekt"
 
@@ -318,10 +363,17 @@ msgstr "E-Rechnung ist nicht korrekt"
 msgid "E Invoicing"
 msgstr ""
 
-#. Label of a Attach field in DocType 'E Invoice Import'
+#. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
 msgstr "E-Rechnung"
+
+#. Label of a Desktop Icon
+#. Title of a Workspace Sidebar
+#: eu_einvoice/desktop_icon/e_invoicing.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "E-Invoicing"
+msgstr ""
 
 #: eu_einvoice/custom_fields.py:63 eu_einvoice/custom_fields.py:85
 #: eu_einvoice/custom_fields.py:107
@@ -344,30 +396,32 @@ msgstr "Eingebettetes Dokument"
 msgid "Error Message"
 msgstr "Fehlermeldung"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:51
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:52
 msgid "Field '{0}' does not exist on Sales Invoice doctype"
 msgstr "Feld '{0}' existiert nicht im DocType 'Sales Invoice'"
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:59
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:60
 msgid "Field '{0}' must be of type 'Attach'. Current type: {1}"
 msgstr "Feld '{0}' muss vom Typ 'Anhängen' sein. Aktueller Typ: {1}"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the file_section_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "File Section"
 msgstr "Datei-Abschnitt"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the grand_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Grand Total"
 msgstr "Gesamtbetrag"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the header_section (Section Break) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Header"
 msgstr "Kopfzeile"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_iban (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "IBAN"
 msgstr "IBAN"
@@ -378,28 +432,28 @@ msgstr "IBAN"
 msgid "If set, written to BT-120 (<code>ram:ExemptionReason</code>) on VAT breakdowns where an exemption reason code is emitted. Left unset in the XML when empty."
 msgstr "Wenn ausgefüllt, wird der Text als BT-120 (<code>ram:ExemptionReason</code>) in der Steueraufschlüsselung geschrieben, sobald ein Befreiungsgrundcode ausgegeben wird. Bleibt das Feld leer, wird BT-120 im XML nicht gesetzt."
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the id (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Invoice ID"
 msgstr "Rechnungs-ID"
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the issue_date (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Issue Date"
 msgstr "Ausstellungsdatum"
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the item (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Item"
 msgstr "Artikel"
 
-#. Label of a Table field in DocType 'E Invoice Import'
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the items (Table) field in DocType 'E Invoice Import'
+#. Label of the items_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Items"
 msgstr "Positionen"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the line_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Line Total"
 msgstr "Zeilensumme"
@@ -408,12 +462,13 @@ msgstr "Zeilensumme"
 msgid "Link to {0}"
 msgstr "Mit {0} verknüpfen"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the monetary_summation_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Monetary Summation"
 msgstr "Gesamtbeträge"
 
-#. Label of a Currency field in DocType 'E Invoice Item'
+#. Label of the net_rate (Currency) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Net Rate"
 msgstr "Nettopreis"
@@ -432,17 +487,29 @@ msgstr "Keine E-Rechnung"
 msgid "On submit, only for E Invoice Profile \"XRECHNUNG\""
 msgstr "Nur bei E-Rechnungs-Profil \"XRECHNUNG\" beim Buchen"
 
-#. Label of a Currency field in DocType 'E Invoice Payment Term'
+#. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
+#. Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Partial Amount"
 msgstr "Teilbetrag"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Description of the 'Auto Name Format for XML File' (Data) field in DocType
+#. 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid ""
+"Pattern for the <b>file name</b> of the XML.  <b>.xml</b> is appended automatically. Leave <b>empty</b> to use the document <b>name</b> (Sales Invoice ID). In case of an error, the document <b>name</b> is used as fallback.\n"
+"<br><br>Segments use a <b>dot</b> (<b>.</b>) between literal text and dynamic parts. Example:<br><b>EXAMPLE-.MM.-.{po_no}.-.YYYY</b><ul><li><b>Dates</b>: <b>DD</b>, <b>MM</b>, <b>YYYY</b>, <b>YY</b>, <b>WW</b>, <b>timestamp</b></li><li><b>Fields</b>: <b>Sales Invoice</b> field names in braces, e.g. <b>{po_no}</b></li><li>Other segments are treated as literal text.</li></ul>"
+msgstr ""
+"Muster für den <b>Dateinamen</b> der XML-Datei. <b>.xml</b> wird automatisch angehängt. <b>Leer lassen</b>, um den Dokumentnamen zu verwenden (ID der Ausgangsrechnung). Bei einem Fehler wird der Dokumentname als Fallback verwendet.\n"
+"<br><br>Literaltext und dynamische Teile werden mit einem <b>Punkt</b> (<b>.</b>) getrennt. Beispiel:<br><b>BEISPIEL-.MM.-.{po_no}.-.YYYY</b><ul><li><b>Datumsangaben</b>: <b>DD</b>, <b>MM</b>, <b>YYYY</b>, <b>YY</b>, <b>WW</b>, <b>timestamp</b></li><li><b>Felder</b>: Feldnamen der <b>Ausgangsrechnung</b> in geschweiften Klammern, z. B. <b>{po_no}</b></li><li>Alle übrigen Abschnitte sind fester Text.</li></ul>"
+
+#. Label of the payment_means_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Means"
 msgstr "Zahlungsmittel"
 
-#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of the payment_terms (Table) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
@@ -463,30 +530,27 @@ msgstr "Bitte beachten Sie die Validierungsfehler der E-Rechnung."
 msgid "Please select a company before submitting"
 msgstr "Bitte vor dem Buchen ein Unternehmen auswählen."
 
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the product_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product"
 msgstr "Produkt"
 
-#. Label of a Small Text field in DocType 'E Invoice Item'
+#. Label of the product_description (Small Text) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Description"
 msgstr "Produktbeschreibung"
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the product_name (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Name"
 msgstr "Produktname"
 
-#. Label of a Read Only field in DocType 'E Invoice Import'
+#. Label of the profile (Read Only) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Profile"
 msgstr "Profil"
-
-#. Linked DocType in E Invoice Import's connections
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
-msgid "Purchase Invoice"
-msgstr "Eingangsrechnung"
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:647
 msgid "Purchase Invoice {0} is already linked to E Invoice Import {1}"
@@ -497,12 +561,12 @@ msgstr "Eingangsrechnung {0} ist bereits mit E-Rechnungs-Import {1} verknüpft"
 msgid "Purchase Manager"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the purchase_order (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Purchase Order"
 msgstr "Lieferantenauftrag"
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the po_detail (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Purchase Order Row"
 msgstr ""
@@ -512,7 +576,8 @@ msgstr ""
 msgid "Purchase User"
 msgstr ""
 
-#. Label of a Percent field in DocType 'E Invoice Trade Tax'
+#. Label of the rate_applicable_percent (Percent) field in DocType 'E Invoice
+#. Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Rate Applicable Percent"
 msgstr "Anwendbarer Prozentsatz"
@@ -521,84 +586,98 @@ msgstr "Anwendbarer Prozentsatz"
 msgid "Row {0}"
 msgstr "Zeile {0}"
 
-#. Label of a Section Break field in DocType 'E Invoice Settings'
+#. Label of the sales_invoice_section (Section Break) field in DocType 'E
+#. Invoice Settings'
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "Sales Invoice"
 msgstr "Ausgangsrechnung"
 
-#. Label of a Autocomplete field in DocType 'E Invoice Settings'
+#. Label of the sales_invoice_number_field (Autocomplete) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice Number Field"
 msgstr "Rechnungsnummer-Feld"
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the seller_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller"
 msgstr "Verkäufer"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_address_line_1 (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 1"
 msgstr "Verkäufer-Adresse Zeile 1"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_address_line_2 (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 2"
 msgstr "Verkäufer-Adresse Zeile 2"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_city (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller City"
 msgstr "Verkäufer-Stadt"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the seller_country (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Country"
 msgstr "Verkäufer-Land"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_electronic_address (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address"
 msgstr "Elektronische Adresse des Verkäufers"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_electronic_address_scheme (Data) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address Scheme"
 msgstr "Schema der elektronischen Adresse des Verkäufers"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Name"
 msgstr "Verkäufer-Name"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_postcode (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Postcode"
 msgstr "Verkäufer-Postleitzahl"
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the seller_product_id (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Seller Product ID"
 msgstr "Verkäufer-Produkt-ID"
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_tax_id (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Tax ID"
 msgstr "Verkäufer-Steuer-ID"
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Settings"
+msgstr ""
+
+#. Label of the settlement_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of the settlement_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Settlement"
 msgstr "Ausgleich"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the supplier (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
 msgstr "Lieferant"
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the supplier_address (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
 msgstr "Lieferanten-Adresse"
@@ -613,27 +692,27 @@ msgstr "Lieferantenrechnungsdatei"
 msgid "System Manager"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Trade Tax'
+#. Label of the tax_account (Link) field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Tax Account"
 msgstr "Steuer-Konto"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the tax_basis_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Basis Total"
 msgstr "Steuerbasis gesamt"
 
-#. Label of a Percent field in DocType 'E Invoice Item'
+#. Label of the tax_rate (Percent) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Tax Rate"
 msgstr "Steuersatz"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the tax_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Total"
 msgstr "Steuer gesamt"
 
-#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of the taxes (Table) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Taxes"
 msgstr "Steuern"
@@ -646,22 +725,22 @@ msgstr "Das Format der hochgeladenen Datei ({0}) wird für E-Rechnungen nicht un
 msgid "The uploaded file does not contain valid XML data."
 msgstr "Die hochgeladene Datei enthält keine gültige XML-Daten."
 
-#. Label of a Currency field in DocType 'E Invoice Item'
+#. Label of the total_amount (Currency) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Total Amount"
 msgstr "Gesamtbetrag"
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the total_prepaid (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Total Prepaid"
 msgstr "Vorausbezahlt"
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the uom (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "UOM"
 msgstr "Einheit"
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the unit_code (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Unit Code"
 msgstr "Einheits-Code"
@@ -675,38 +754,43 @@ msgstr "Nicht unterstütztes Dateiformat"
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr "Laden Sie die von Ihrem Lieferanten bereitgestellte <code>.xml</code>- oder <code>.pdf</code>-Datei hoch."
 
-#. Label of a Section Break field in DocType 'E Invoice Settings'
+#. Label of the section_break_bt120 (Section Break) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "VAT exemption (e-invoice)"
 msgstr "Umsatzsteuerbefreiung (E-Rechnung)"
 
-#. Label of a Small Text field in DocType 'E Invoice Trade Tax'
+#. Label of the vat_exemption_reason_text (Small Text) field in DocType 'E
+#. Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "VAT exemption reason"
 msgstr "Grund für Umsatzsteuerbefreiung"
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Save"
 msgstr "E-Rechnung beim Speichern validieren"
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Submit"
 msgstr "E-Rechnung beim Buchen validieren"
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the validation_details_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Details"
 msgstr "Validierungsdetails"
 
-#. Label of a Text field in DocType 'E Invoice Import'
+#. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:175
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
 msgstr "Validierungsfehler"
 
-#. Label of a Text field in DocType 'E Invoice Import'
+#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:185
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Warnings"
@@ -723,19 +807,19 @@ msgstr "{0} ansehen"
 msgid "Warning Message"
 msgstr "Warnung"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:782
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:784
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:771
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:773
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr "Die Gebührenart 'Tatsächlich' wird nur in den E-Rechnungs-Profilen 'EXTENDED' und 'XRECHNUNG' unterstützt."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:759
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:761
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:794
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:796
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/de.po
+++ b/eu_einvoice/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-04-28 15:18+0053\n"
+"POT-Creation-Date: 2026-05-08 09:09+0053\n"
 "PO-Revision-Date: 2026-02-05 11:13+0100\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language: de\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:805
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:809
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr "Ein Rabatt auf der Dokumentebene wird in der E-Rechnung derzeit nicht unterstützt."
 
@@ -187,11 +187,11 @@ msgstr "Berechneter Betrag"
 msgid "Calculation Percent"
 msgstr "Berechnung Prozentsatz"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:836
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:840
 msgid "Cannot create E Invoice."
 msgstr "E-Rechnung konnte nicht erstellt werden."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:850
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:854
 msgid "Cannot validate E Invoice schematron."
 msgstr "E-Rechnung konnte nicht validiert werden."
 
@@ -350,11 +350,11 @@ msgstr "E-Rechnungs-Einstellungen"
 msgid "E Invoice Trade Tax"
 msgstr "E-Rechnungs-Steuer"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1181
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1185
 msgid "E Invoice XML file name pattern failed"
 msgstr "Namensmuster für E-Rechnungs-XML-Datei fehlgeschlagen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:818
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:822
 msgid "E Invoice is not correct"
 msgstr "E-Rechnung ist nicht korrekt"
 
@@ -807,19 +807,25 @@ msgstr "{0} ansehen"
 msgid "Warning Message"
 msgstr "Warnung"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:784
+#. Label of the section_break_yldr (Section Break) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "XML Settings"
+msgstr "XML-Einstellungen"
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:788
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr "{0} Zeile {1}: Rabatt-Datum sollte nach Buchungsdatum liegen"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:773
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:777
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr "Die Gebührenart 'Tatsächlich' wird nur in den E-Rechnungs-Profilen 'EXTENDED' und 'XRECHNUNG' unterstützt."
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:761
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:765
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr "{0} Zeile #{1}: Typ '{2}' wird in der E-Rechnung nicht unterstützt"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:796
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:800
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr "{0}: Nur eine Zahlungsart wird in der E-Rechnung berücksichtigt."
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,35 +7,38 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-04-21 15:04+0000\n"
-"PO-Revision-Date: 2026-04-21 15:04+0000\n"
+"POT-Creation-Date: 2026-04-28 15:18+0053\n"
+"PO-Revision-Date: 2026-04-28 15:18+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:803
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:805
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_account_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Account Name"
 msgstr ""
 
-#. Label of a Select field in DocType 'E Invoice Settings'
+#. Label of the error_action_on_save (Select) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Save"
 msgstr ""
 
-#. Label of a Select field in DocType 'E Invoice Settings'
+#. Label of the error_action_on_submit (Select) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Action on Validation Error during Submit"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Payment Term'
+#. Label of the discount_actual_amount (Currency) field in DocType 'E Invoice
+#. Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Actual Amount"
 msgstr ""
@@ -44,17 +47,18 @@ msgstr ""
 msgid "Additional supporting document to be embedded in the e-invoice file."
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the agreement_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Agreement"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the allowance_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Allowance Total"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the amended_from (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Amended From"
 msgstr ""
@@ -63,92 +67,103 @@ msgstr ""
 msgid "An E Invoice Import with the same Invoice ID and Supplier already exists."
 msgstr ""
 
-#. Label of a Autocomplete field in DocType 'E Invoice Settings'
+#. Label of the attach_field_for_xml_file (Autocomplete) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Attach Field for XML File"
 msgstr ""
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the auto_name_format_for_xml_file (Data) field in DocType 'E
+#. Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "Auto Name Format for XML File"
+msgstr ""
+
+#. Label of the auto_attach_xml (Check) field in DocType 'E Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Auto-attach XML File"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_bic (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "BIC"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Trade Tax'
+#. Label of the basis_amount (Currency) field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Basis Amount"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Payment Term'
+#. Label of the discount_basis_date (Date) field in DocType 'E Invoice Payment
+#. Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Basis Date"
 msgstr ""
 
-#. Label of a Float field in DocType 'E Invoice Item'
+#. Label of the billed_quantity (Float) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Billed Quantity"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the billing_period_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the billing_period_end (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period End"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the billing_period_start (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Billing Period Start"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the buyer_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_address_line_1 (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 1"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_address_line_2 (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Address Line 2"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_city (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer City"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the buyer_country (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Country"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_electronic_address (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_electronic_address_scheme (Data) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Electronic Address Scheme"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Name"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the buyer_postcode (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Buyer Postcode"
 msgstr ""
@@ -158,30 +173,42 @@ msgstr ""
 msgid "Buyer Reference"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Trade Tax'
+#. Label of the calculated_amount (Currency) field in DocType 'E Invoice Trade
+#. Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Calculated Amount"
 msgstr ""
 
-#. Label of a Percent field in DocType 'E Invoice Payment Term'
+#. Label of the discount_calculation_percent (Percent) field in DocType 'E
+#. Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:834
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:836
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:848
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:850
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the charge_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Charge Total"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Code List"
+msgstr ""
+
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Common Code"
+msgstr ""
+
+#. Label of the company (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Company"
 msgstr ""
@@ -200,7 +227,7 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#. Label of a Button field in DocType 'E Invoice Item'
+#. Label of the create_item (Button) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Create Item"
 msgstr ""
@@ -210,66 +237,77 @@ msgstr ""
 msgid "Create Purchase Invoice"
 msgstr ""
 
-#. Label of a Button field in DocType 'E Invoice Import'
+#. Label of the create_supplier (Button) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier"
 msgstr ""
 
-#. Label of a Button field in DocType 'E Invoice Import'
+#. Label of the create_supplier_address (Button) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Create Supplier Address"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the currency (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Currency"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'E Invoice Settings'
+#. Label of the vat_exemption_reason_text (Small Text) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Default VAT exemption reason"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the delivery_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of the delivery_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Delivery"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Payment Term'
+#. Label of the section_break_mgef (Section Break) field in DocType 'E Invoice
+#. Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Discount"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the document_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Document"
+msgstr ""
+
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Documentation"
 msgstr ""
 
 #: eu_einvoice/european_e_invoice/custom/sales_invoice.js:14
 msgid "Download eInvoice"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Payment Term'
+#. Label of the due (Date) field in DocType 'E Invoice Payment Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Due"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the due_date (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Date"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the due_payable (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Due Payable"
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/custom_fields.py:19
 #: eu_einvoice/european_e_invoice/custom/purchase_order.js:5
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "E Invoice Import"
 msgstr ""
 
@@ -277,7 +315,8 @@ msgstr ""
 msgid "E Invoice Import {0} does not exist"
 msgstr ""
 
-#. Label of a Check field in DocType 'E Invoice Import'
+#. Label of the e_invoice_is_correct (Check) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/custom_fields.py:165
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E Invoice Is Correct"
@@ -298,7 +337,9 @@ msgid "E Invoice Profile"
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "E Invoice Settings"
 msgstr ""
 
@@ -307,7 +348,11 @@ msgstr ""
 msgid "E Invoice Trade Tax"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:816
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1181
+msgid "E Invoice XML file name pattern failed"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:818
 msgid "E Invoice is not correct"
 msgstr ""
 
@@ -316,9 +361,16 @@ msgstr ""
 msgid "E Invoicing"
 msgstr ""
 
-#. Label of a Attach field in DocType 'E Invoice Import'
+#. Label of the einvoice (Attach) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "E-Invoice"
+msgstr ""
+
+#. Label of a Desktop Icon
+#. Title of a Workspace Sidebar
+#: eu_einvoice/desktop_icon/e_invoicing.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "E-Invoicing"
 msgstr ""
 
 #: eu_einvoice/custom_fields.py:63 eu_einvoice/custom_fields.py:85
@@ -343,30 +395,32 @@ msgstr ""
 msgid "Error Message"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:51
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:52
 msgid "Field '{0}' does not exist on Sales Invoice doctype"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:59
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py:60
 msgid "Field '{0}' must be of type 'Attach'. Current type: {1}"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the file_section_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "File Section"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the grand_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Grand Total"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the header_section (Section Break) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Header"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the payee_iban (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "IBAN"
 msgstr ""
@@ -377,28 +431,28 @@ msgstr ""
 msgid "If set, written to BT-120 (<code>ram:ExemptionReason</code>) on VAT breakdowns where an exemption reason code is emitted. Left unset in the XML when empty."
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the id (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Invoice ID"
 msgstr ""
 
-#. Label of a Date field in DocType 'E Invoice Import'
+#. Label of the issue_date (Date) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Issue Date"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the item (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Item"
 msgstr ""
 
-#. Label of a Table field in DocType 'E Invoice Import'
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the items (Table) field in DocType 'E Invoice Import'
+#. Label of the items_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Items"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the line_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Line Total"
 msgstr ""
@@ -407,12 +461,13 @@ msgstr ""
 msgid "Link to {0}"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the monetary_summation_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Monetary Summation"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Item'
+#. Label of the net_rate (Currency) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Net Rate"
 msgstr ""
@@ -431,17 +486,27 @@ msgstr ""
 msgid "On submit, only for E Invoice Profile \"XRECHNUNG\""
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Payment Term'
+#. Label of the partial_amount (Currency) field in DocType 'E Invoice Payment
+#. Term'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_payment_term/e_invoice_payment_term.json
 msgid "Partial Amount"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Description of the 'Auto Name Format for XML File' (Data) field in DocType
+#. 'E Invoice Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid ""
+"Pattern for the <b>file name</b> of the XML.  <b>.xml</b> is appended automatically. Leave <b>empty</b> to use the document <b>name</b> (Sales Invoice ID). In case of an error, the document <b>name</b> is used as fallback.\n"
+"<br><br>Segments use a <b>dot</b> (<b>.</b>) between literal text and dynamic parts. Example:<br><b>EXAMPLE-.MM.-.{po_no}.-.YYYY</b><ul><li><b>Dates</b>: <b>DD</b>, <b>MM</b>, <b>YYYY</b>, <b>YY</b>, <b>WW</b>, <b>timestamp</b></li><li><b>Fields</b>: <b>Sales Invoice</b> field names in braces, e.g. <b>{po_no}</b></li><li>Other segments are treated as literal text.</li></ul>"
+msgstr ""
+
+#. Label of the payment_means_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Means"
 msgstr ""
 
-#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of the payment_terms (Table) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Payment Terms"
 msgstr ""
@@ -462,29 +527,26 @@ msgstr ""
 msgid "Please select a company before submitting"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of the product_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'E Invoice Item'
+#. Label of the product_description (Small Text) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Description"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the product_name (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Product Name"
 msgstr ""
 
-#. Label of a Read Only field in DocType 'E Invoice Import'
+#. Label of the profile (Read Only) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Profile"
-msgstr ""
-
-#. Linked DocType in E Invoice Import's connections
-#: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
-msgid "Purchase Invoice"
 msgstr ""
 
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.py:647
@@ -496,12 +558,12 @@ msgstr ""
 msgid "Purchase Manager"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the purchase_order (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Purchase Order"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the po_detail (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Purchase Order Row"
 msgstr ""
@@ -511,7 +573,8 @@ msgstr ""
 msgid "Purchase User"
 msgstr ""
 
-#. Label of a Percent field in DocType 'E Invoice Trade Tax'
+#. Label of the rate_applicable_percent (Percent) field in DocType 'E Invoice
+#. Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Rate Applicable Percent"
 msgstr ""
@@ -520,84 +583,98 @@ msgstr ""
 msgid "Row {0}"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Settings'
+#. Label of the sales_invoice_section (Section Break) field in DocType 'E
+#. Invoice Settings'
+#. Label of a Workspace Sidebar Item
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
 msgid "Sales Invoice"
 msgstr ""
 
-#. Label of a Autocomplete field in DocType 'E Invoice Settings'
+#. Label of the sales_invoice_number_field (Autocomplete) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Sales Invoice Number Field"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
+#. Label of the seller_tab (Tab Break) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_address_line_1 (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 1"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_address_line_2 (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Address Line 2"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_city (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller City"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the seller_country (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Country"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_electronic_address (Data) field in DocType 'E Invoice
+#. Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_electronic_address_scheme (Data) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Electronic Address Scheme"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_name (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Name"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_postcode (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Postcode"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the seller_product_id (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Seller Product ID"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Import'
+#. Label of the seller_tax_id (Data) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Seller Tax ID"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'E Invoice Import'
-#. Label of a Section Break field in DocType 'E Invoice Item'
+#. Label of a Workspace Sidebar Item
+#: eu_einvoice/workspace_sidebar/e_invoicing.json
+msgid "Settings"
+msgstr ""
+
+#. Label of the settlement_tab (Tab Break) field in DocType 'E Invoice Import'
+#. Label of the settlement_section (Section Break) field in DocType 'E Invoice
+#. Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Settlement"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the supplier (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Import'
+#. Label of the supplier_address (Link) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Supplier Address"
 msgstr ""
@@ -612,27 +689,27 @@ msgstr ""
 msgid "System Manager"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Trade Tax'
+#. Label of the tax_account (Link) field in DocType 'E Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "Tax Account"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the tax_basis_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Basis Total"
 msgstr ""
 
-#. Label of a Percent field in DocType 'E Invoice Item'
+#. Label of the tax_rate (Percent) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Tax Rate"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the tax_total (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Tax Total"
 msgstr ""
 
-#. Label of a Table field in DocType 'E Invoice Import'
+#. Label of the taxes (Table) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Taxes"
 msgstr ""
@@ -645,22 +722,22 @@ msgstr ""
 msgid "The uploaded file does not contain valid XML data."
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Item'
+#. Label of the total_amount (Currency) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Total Amount"
 msgstr ""
 
-#. Label of a Currency field in DocType 'E Invoice Import'
+#. Label of the total_prepaid (Currency) field in DocType 'E Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Total Prepaid"
 msgstr ""
 
-#. Label of a Link field in DocType 'E Invoice Item'
+#. Label of the uom (Link) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "UOM"
 msgstr ""
 
-#. Label of a Data field in DocType 'E Invoice Item'
+#. Label of the unit_code (Data) field in DocType 'E Invoice Item'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_item/e_invoice_item.json
 msgid "Unit Code"
 msgstr ""
@@ -674,38 +751,43 @@ msgstr ""
 msgid "Upload the <code>.xml</code> or <code>.pdf</code> file provided by your supplier."
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Settings'
+#. Label of the section_break_bt120 (Section Break) field in DocType 'E Invoice
+#. Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "VAT exemption (e-invoice)"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'E Invoice Trade Tax'
+#. Label of the vat_exemption_reason_text (Small Text) field in DocType 'E
+#. Invoice Trade Tax'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_trade_tax/e_invoice_trade_tax.json
 msgid "VAT exemption reason"
 msgstr ""
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the validate_sales_invoice_on_save (Check) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Save"
 msgstr ""
 
-#. Label of a Check field in DocType 'E Invoice Settings'
+#. Label of the validate_sales_invoice_on_submit (Check) field in DocType 'E
+#. Invoice Settings'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
 msgid "Validate Sales Invoice on Submit"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'E Invoice Import'
+#. Label of the validation_details_section (Section Break) field in DocType 'E
+#. Invoice Import'
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Details"
 msgstr ""
 
-#. Label of a Text field in DocType 'E Invoice Import'
+#. Label of the validation_errors (Text) field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:175
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Errors"
 msgstr ""
 
-#. Label of a Text field in DocType 'E Invoice Import'
+#. Label of the validation_warnings (Text) field in DocType 'E Invoice Import'
 #: eu_einvoice/custom_fields.py:185
 #: eu_einvoice/european_e_invoice/doctype/e_invoice_import/e_invoice_import.json
 msgid "Validation Warnings"
@@ -723,19 +805,19 @@ msgstr ""
 msgid "Warning Message"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:782
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:784
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:771
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:773
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:759
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:761
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:794
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:796
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 

--- a/eu_einvoice/locale/main.pot
+++ b/eu_einvoice/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: European e-Invoice VERSION\n"
 "Report-Msgid-Bugs-To: hallo@alyf.de\n"
-"POT-Creation-Date: 2026-04-28 15:18+0053\n"
-"PO-Revision-Date: 2026-04-28 15:18+0053\n"
+"POT-Creation-Date: 2026-05-08 09:09+0053\n"
+"PO-Revision-Date: 2026-05-08 09:09+0053\n"
 "Last-Translator: hallo@alyf.de\n"
 "Language-Team: hallo@alyf.de\n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:805
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:809
 msgid "A document level discount is currently not supported in the e-invoice."
 msgstr ""
 
@@ -185,11 +185,11 @@ msgstr ""
 msgid "Calculation Percent"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:836
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:840
 msgid "Cannot create E Invoice."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:850
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:854
 msgid "Cannot validate E Invoice schematron."
 msgstr ""
 
@@ -348,11 +348,11 @@ msgstr ""
 msgid "E Invoice Trade Tax"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1181
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:1185
 msgid "E Invoice XML file name pattern failed"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:818
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:822
 msgid "E Invoice is not correct"
 msgstr ""
 
@@ -805,19 +805,25 @@ msgstr ""
 msgid "Warning Message"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:784
+#. Label of the section_break_yldr (Section Break) field in DocType 'E Invoice
+#. Settings'
+#: eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.json
+msgid "XML Settings"
+msgstr ""
+
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:788
 msgid "{0} row #{1}: Discount Date should be after Posting Date"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:773
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:777
 msgid "{0} row #{1}: The charge type 'Actual' is only supported in the eInvoice profiles 'EXTENDED' and 'XRECHNUNG'."
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:761
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:765
 msgid "{0} row #{1}: Type '{2}' is not supported in e-invoice"
 msgstr ""
 
-#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:796
+#: eu_einvoice/european_e_invoice/custom/sales_invoice.py:800
 msgid "{0}: Only one mode of payment will be considered in the e-invoice."
 msgstr ""
 


### PR DESCRIPTION
- Added E Invoice Settings field for global autonaming pattern for XML attachements.
- Added `get_xml_attachment_file_base_name` function to resolve file names.
- Introduced unit tests for various naming scenarios in `test_xml_attachment_naming.py`.
- Updated Sales Invoice logic to utilize the new naming function for XML file attachments.
- Integrated autonaming pattern into "Download XML" button on Sales Invoice.

Ref: IBT-164
closes #245 