### PR TITLE
ci: enable server tests and align workflow tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,6 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           bench --site test_site set-config allow_tests true
-          bench --site test_site run-tests --app eu_einvoice
+          bench --site test_site run-tests --app eu_einvoice --lightmode
         env:
           TYPE: server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app eu_einvoice
-          bench --site test_site execute frappe.utils.install.complete_setup_wizard
           bench build
         env:
           CI: 'Yes'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,16 +111,15 @@ jobs:
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app eu_einvoice
+          bench --site test_site execute frappe.utils.install.complete_setup_wizard
           bench build
         env:
           CI: 'Yes'
 
-      # TODO: add provision to run setup wizard on install, before renabling this step
-      #
-      # - name: Run Tests
-      #   working-directory: /home/runner/frappe-bench
-      #   run: |
-      #     bench --site test_site set-config allow_tests true
-      #     bench --site test_site run-tests --app eu_einvoice
-      #   env:
-      #     TYPE: server
+      - name: Run Tests
+        working-directory: /home/runner/frappe-bench
+        run: |
+          bench --site test_site set-config allow_tests true
+          bench --site test_site run-tests --app eu_einvoice
+        env:
+          TYPE: server

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -31,7 +31,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 200
       - uses: actions/setup-node@v6
@@ -50,7 +50,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'
@@ -73,10 +73,10 @@ jobs:
         with:
           python-version: '3.14'
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py') }}
@@ -96,7 +96,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: '3.14'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tags
 node_modules
 __pycache__
+.vscode/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
       - id: check-ast
       - id: check-json
       - id: check-toml
-      - id: check-yaml
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Run ERPNext setup wizard on the temporary CI site before bench run-tests --app eu_einvoice. Re-enable the CI / Server test step disabled since 2024.

Additional CI tweaks:

- Bump linter workflow to actions/checkout@v6 and actions/cache@v5. 
- Remove duplicate check-yaml pre-commit hook.

Refs #264