### PR TITLE
fix(sales_invoice): deduplicate ApplicableTradeTax on header per EN 16931 BR-30

### DIFF
--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -502,6 +502,67 @@ class EInvoiceGenerator:
 		li.settlement.monetary_summation.total_amount = flt(item.net_amount, item.precision("net_amount"))
 		self.doc.trade.items.add(li)
 
+	def _merge_or_add_header_trade_tax(self, trade_tax):
+		"""Add ApplicableTradeTax to the header, merging with an existing entry that
+		shares the same (type_code, category_code, rate_applicable_percent) tuple.
+
+		EN 16931 rule BR-30 (and CII-SR-045 / BR-CO-18) require that per unique
+		combination of VAT category code and VAT rate there is exactly ONE
+		ApplicableTradeTax element in ApplicableHeaderTradeSettlement.
+
+		Some ERPNext configurations produce multiple Sales Invoice tax rows that
+		collapse to the same (category, rate) tuple in the XML — most commonly when
+		an Item Tax Template covers both output and input tax accounts (e.g. the
+		default `19 % - PO` template shipped by erpnext_germany). Without merging,
+		the generated XML contains N identical <ram:ApplicableTradeTax> blocks and
+		the TaxTotalAmount / GrandTotalAmount computed by validators becomes N× the
+		correct value.
+
+		Behaviour:
+		    * First occurrence of a key → added to `trade_tax` collection and indexed.
+		    * Later occurrence with basis+calc identical → dropped (pure duplicate).
+		    * Later occurrence with different basis or calc → basis+calc summed into
+		      the existing entry, so the resulting Header value equals the sum of
+		      individual invoice tax rows sharing that (category, rate).
+		"""
+
+		def _val(field):
+			if field is None:
+				return None
+			# drafthorse DecimalElement exposes ._value, StringElement uses ._text
+			v = getattr(field, "_value", None)
+			if v is not None:
+				return v
+			return getattr(field, "_text", None)
+
+		key = (
+			_val(trade_tax.type_code) or "",
+			_val(trade_tax.category_code) or "",
+			float(_val(trade_tax.rate_applicable_percent) or 0),
+		)
+
+		if not hasattr(self, "_header_trade_tax_index"):
+			self._header_trade_tax_index = {}
+
+		existing = self._header_trade_tax_index.get(key)
+		if existing is None:
+			self._header_trade_tax_index[key] = trade_tax
+			self.doc.trade.settlement.trade_tax.add(trade_tax)
+			return
+
+		existing_basis = float(_val(existing.basis_amount) or 0)
+		new_basis = float(_val(trade_tax.basis_amount) or 0)
+		existing_calc = float(_val(existing.calculated_amount) or 0)
+		new_calc = float(_val(trade_tax.calculated_amount) or 0)
+
+		# Identical duplicate → nothing to do
+		if abs(existing_basis - new_basis) < 0.01 and abs(existing_calc - new_calc) < 0.01:
+			return
+
+		# Genuine aggregation → sum into the existing element
+		existing.basis_amount = existing_basis + new_basis
+		existing.calculated_amount = existing_calc + new_calc
+
 	def _add_taxes_and_charges(self):
 		tax_added = False
 		for i, tax in enumerate(self.invoice.taxes):
@@ -558,7 +619,7 @@ class EInvoiceGenerator:
 				else:
 					trade_tax.basis_amount = 0
 
-				self.doc.trade.settlement.trade_tax.add(trade_tax)
+				self._merge_or_add_header_trade_tax(trade_tax)
 				tax_added = True
 			elif tax.charge_type == "On Previous Row Amount":
 				trade_tax = ApplicableTradeTax()
@@ -580,7 +641,7 @@ class EInvoiceGenerator:
 						("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 					]
 				)
-				self.doc.trade.settlement.trade_tax.add(trade_tax)
+				self._merge_or_add_header_trade_tax(trade_tax)
 				tax_added = True
 			elif tax.charge_type == "On Previous Row Total":
 				trade_tax = ApplicableTradeTax()
@@ -602,7 +663,7 @@ class EInvoiceGenerator:
 						("Sales Taxes and Charges Template", self.invoice.taxes_and_charges),
 					]
 				)
-				self.doc.trade.settlement.trade_tax.add(trade_tax)
+				self._merge_or_add_header_trade_tax(trade_tax)
 				tax_added = True
 
 		return tax_added

--- a/eu_einvoice/european_e_invoice/custom/sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/sales_invoice.py
@@ -140,6 +140,11 @@ class EInvoiceGenerator:
 	def create_einvoice(self):
 		"""Create the einvoice document as a Python object."""
 		self.doc = Document()
+		# Per-document header ApplicableTradeTax index used by
+		# `_merge_or_add_header_trade_tax`. Reset alongside `self.doc` so the
+		# helper never merges into orphaned elements from a previous call.
+		self._header_trade_tax_index = {}
+		self._header_trade_tax_seen_amounts = {}
 		self.vat_exemption_reason_text = str(
 			frappe.db.get_single_value("E Invoice Settings", "vat_exemption_reason_text") or ""
 		).strip()
@@ -520,10 +525,14 @@ class EInvoiceGenerator:
 
 		Behaviour:
 		    * First occurrence of a key → added to `trade_tax` collection and indexed.
-		    * Later occurrence with basis+calc identical → dropped (pure duplicate).
-		    * Later occurrence with different basis or calc → basis+calc summed into
+		    * Later occurrence with (basis_amount, calculated_amount) pair already
+		      seen for this key → dropped (pure duplicate).
+		    * Later occurrence with new (basis, calc) pair → basis+calc summed into
 		      the existing entry, so the resulting Header value equals the sum of
 		      individual invoice tax rows sharing that (category, rate).
+
+		The seen-pair set is tracked per key so mixed sequences of duplicates and
+		genuinely distinct rows aggregate correctly regardless of order.
 		"""
 
 		def _val(field):
@@ -540,26 +549,27 @@ class EInvoiceGenerator:
 			_val(trade_tax.category_code) or "",
 			float(_val(trade_tax.rate_applicable_percent) or 0),
 		)
-
-		if not hasattr(self, "_header_trade_tax_index"):
-			self._header_trade_tax_index = {}
+		new_basis = float(_val(trade_tax.basis_amount) or 0)
+		new_calc = float(_val(trade_tax.calculated_amount) or 0)
+		# Round to 2 dp for stable duplicate detection across currency-level precision
+		amounts = (round(new_basis, 2), round(new_calc, 2))
 
 		existing = self._header_trade_tax_index.get(key)
 		if existing is None:
 			self._header_trade_tax_index[key] = trade_tax
+			self._header_trade_tax_seen_amounts[key] = {amounts}
 			self.doc.trade.settlement.trade_tax.add(trade_tax)
 			return
 
-		existing_basis = float(_val(existing.basis_amount) or 0)
-		new_basis = float(_val(trade_tax.basis_amount) or 0)
-		existing_calc = float(_val(existing.calculated_amount) or 0)
-		new_calc = float(_val(trade_tax.calculated_amount) or 0)
-
-		# Identical duplicate → nothing to do
-		if abs(existing_basis - new_basis) < 0.01 and abs(existing_calc - new_calc) < 0.01:
+		seen = self._header_trade_tax_seen_amounts[key]
+		if amounts in seen:
+			# Already accounted for by an earlier row with the same amounts
 			return
 
-		# Genuine aggregation → sum into the existing element
+		# Genuinely new (basis, calc) under an existing key → aggregate into existing
+		seen.add(amounts)
+		existing_basis = float(_val(existing.basis_amount) or 0)
+		existing_calc = float(_val(existing.calculated_amount) or 0)
 		existing.basis_amount = existing_basis + new_basis
 		existing.calculated_amount = existing_calc + new_calc
 

--- a/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
@@ -68,9 +68,12 @@ class TestHeaderTradeTaxDeduplication(FrappeTestCase):
 	(EN 16931 rule BR-30, CII-SR-045)."""
 
 	def _make_generator(self):
-		"""Return a bare EInvoiceGenerator instance with just a Document attached."""
+		"""Return a bare EInvoiceGenerator with the state that create_einvoice()
+		initialises, matching the runtime lifecycle."""
 		generator = EInvoiceGenerator.__new__(EInvoiceGenerator)
 		generator.doc = Document()
+		generator._header_trade_tax_index = {}
+		generator._header_trade_tax_seen_amounts = {}
 		return generator
 
 	def _make_tax(self, *, type_code="VAT", category="S", rate=19.0, basis=100.0, calc=19.0):
@@ -140,3 +143,30 @@ class TestHeaderTradeTaxDeduplication(FrappeTestCase):
 		taxes = self._header_taxes(gen)
 		self.assertEqual(len(taxes), 1)
 		self.assertAlmostEqual(taxes[0].basis_amount._value, 100.0)
+
+	def test_duplicate_after_aggregation_is_still_dropped(self):
+		"""Sequence [100, 50, 100] under the same key must yield basis=150
+		(not 250) — the third entry duplicates the first and must not be
+		summed in a second time even though the accumulator already reads 150."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=100.0, calc=19.0))
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=50.0, calc=9.5))
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=100.0, calc=19.0))
+		taxes = self._header_taxes(gen)
+		self.assertEqual(len(taxes), 1)
+		self.assertAlmostEqual(taxes[0].basis_amount._value, 150.0)
+		self.assertAlmostEqual(taxes[0].calculated_amount._value, 28.5)
+
+	def test_state_isolation_between_generators(self):
+		"""Two generators must not share header trade tax state, matching the
+		reset performed by create_einvoice() on each call."""
+		gen_a = self._make_generator()
+		gen_a._merge_or_add_header_trade_tax(self._make_tax(basis=100.0, calc=19.0))
+
+		gen_b = self._make_generator()
+		gen_b._merge_or_add_header_trade_tax(self._make_tax(basis=200.0, calc=38.0))
+
+		taxes_b = self._header_taxes(gen_b)
+		self.assertEqual(len(taxes_b), 1)
+		self.assertAlmostEqual(taxes_b[0].basis_amount._value, 200.0)
+		self.assertEqual(len(self._header_taxes(gen_a)), 1)

--- a/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
+++ b/eu_einvoice/european_e_invoice/custom/test_sales_invoice.py
@@ -1,9 +1,13 @@
 from unittest.mock import patch
 
 import frappe
+from drafthorse.models.accounting import ApplicableTradeTax
+from drafthorse.models.document import Document
 from frappe.tests.utils import FrappeTestCase
 
 from eu_einvoice.european_e_invoice.custom.sales_invoice import (
+	EInvoiceGenerator,
+	EInvoiceProfile,
 	get_xml_attachment_file_base_name,
 )
 
@@ -56,3 +60,83 @@ class TestXmlAttachmentNaming(FrappeTestCase):
 		doc = frappe._dict(name="SINV-00001", po_no="A/B", doctype="Sales Invoice")
 		base = get_xml_attachment_file_base_name(doc, pattern="{po_no}")
 		self.assertEqual(base, "A_B")
+
+
+class TestHeaderTradeTaxDeduplication(FrappeTestCase):
+	"""Verify that _merge_or_add_header_trade_tax collapses duplicates and sums
+	distinct entries per (type_code, category_code, rate) combination
+	(EN 16931 rule BR-30, CII-SR-045)."""
+
+	def _make_generator(self):
+		"""Return a bare EInvoiceGenerator instance with just a Document attached."""
+		generator = EInvoiceGenerator.__new__(EInvoiceGenerator)
+		generator.doc = Document()
+		return generator
+
+	def _make_tax(self, *, type_code="VAT", category="S", rate=19.0, basis=100.0, calc=19.0):
+		tt = ApplicableTradeTax()
+		tt.type_code = type_code
+		tt.category_code = category
+		tt.rate_applicable_percent = rate
+		tt.basis_amount = basis
+		tt.calculated_amount = calc
+		return tt
+
+	def _header_taxes(self, generator):
+		return list(generator.doc.trade.settlement.trade_tax.children)
+
+	def test_identical_duplicate_is_dropped(self):
+		"""Two identical (S, 19%, basis=100, calc=19) tax rows collapse to one entry."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax())
+		gen._merge_or_add_header_trade_tax(self._make_tax())
+		self.assertEqual(len(self._header_taxes(gen)), 1)
+
+	def test_many_identical_duplicates_collapse_to_one(self):
+		"""Reproduces the observed 13-row Item-Tax-Template pathology from ERPNext."""
+		gen = self._make_generator()
+		for _ in range(13):
+			gen._merge_or_add_header_trade_tax(self._make_tax(basis=227.73, calc=43.27))
+		taxes = self._header_taxes(gen)
+		self.assertEqual(len(taxes), 1)
+		self.assertAlmostEqual(taxes[0].basis_amount._value, 227.73)
+		self.assertAlmostEqual(taxes[0].calculated_amount._value, 43.27)
+
+	def test_distinct_rates_kept_separate(self):
+		"""(S, 19%) and (S, 7%) must remain two distinct entries."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(rate=19.0, basis=100.0, calc=19.0))
+		gen._merge_or_add_header_trade_tax(self._make_tax(rate=7.0, basis=50.0, calc=3.5))
+		self.assertEqual(len(self._header_taxes(gen)), 2)
+
+	def test_distinct_categories_kept_separate(self):
+		"""(S, 19%) and (AE, 19%) must remain two distinct entries."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(category="S"))
+		gen._merge_or_add_header_trade_tax(self._make_tax(category="AE"))
+		self.assertEqual(len(self._header_taxes(gen)), 2)
+
+	def test_distinct_type_codes_kept_separate(self):
+		"""(VAT, S, 19%) and (SUR, S, 19%) must remain two distinct entries."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(type_code="VAT"))
+		gen._merge_or_add_header_trade_tax(self._make_tax(type_code="SUR"))
+		self.assertEqual(len(self._header_taxes(gen)), 2)
+
+	def test_distinct_amounts_same_key_are_summed(self):
+		"""Two (S, 19%) entries with different basis/calc are summed into one."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=100.0, calc=19.0))
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=50.0, calc=9.5))
+		taxes = self._header_taxes(gen)
+		self.assertEqual(len(taxes), 1)
+		self.assertAlmostEqual(taxes[0].basis_amount._value, 150.0)
+		self.assertAlmostEqual(taxes[0].calculated_amount._value, 28.5)
+
+	def test_single_entry_added_unchanged(self):
+		"""A single call is passed through without modification."""
+		gen = self._make_generator()
+		gen._merge_or_add_header_trade_tax(self._make_tax(basis=100.0, calc=19.0))
+		taxes = self._header_taxes(gen)
+		self.assertEqual(len(taxes), 1)
+		self.assertAlmostEqual(taxes[0].basis_amount._value, 100.0)


### PR DESCRIPTION
## Problem

`EInvoiceGenerator._add_taxes_and_charges` iterates every row in a Sales Invoice's `taxes` child table and appends a new `<ram:ApplicableTradeTax>` element to `ApplicableHeaderTradeSettlement` for each one.

When the invoice carries multiple tax rows that map to the **same** `(type_code, category_code, rate_applicable_percent)` tuple, the resulting XML contains N identical `ApplicableTradeTax` blocks. Downstream validators then read the header VAT breakdown as N× the correct amount and reject the document (or, more subtly, quietly accept an inflated `TaxTotalAmount` / `GrandTotalAmount`).

This violates **EN 16931 rule BR-30** ("An Invoice shall have the VAT breakdown per each different value of VAT category rate"), as well as Schematron rules `CII-SR-045` and `BR-CO-18`.

### How it triggers in real life

The most common trigger is an Item Tax Template that covers both output and input tax accounts at 19 %. The `19 % - PO` (SKR03) template shipped by [`erpnext_germany`](https://github.com/alyf-de/erpnext_germany) is a natural example — it lists seven distinct 19 % accounts (regular USt, i.g. Erwerb, § 13b, Vorsteuer variants, Einfuhrumsatzsteuer). If a Sales Invoice is submitted without an explicit `taxes_and_charges` template, ERPNext expands every one of those accounts into a separate tax row on the invoice. `eu_einvoice` faithfully emits seven `<ram:ApplicableTradeTax>` blocks with identical category `S`, rate `19.00`, basis and calculated amounts — and validators multiply `TaxTotalAmount` accordingly.

We hit this with a real invoice (grand total: 271.00 EUR expected, 530.62 EUR reported).

## Fix

Introduce `_merge_or_add_header_trade_tax(self, trade_tax)` which indexes emitted header entries by the `(type_code, category_code, rate_applicable_percent)` tuple:

- **New key** → element is added and indexed, unchanged behaviour.
- **Existing key, identical `basis_amount` and `calculated_amount`** → the new element is dropped (pure duplicate — the ERPNext row explosion case).
- **Existing key, different amounts** → `basis_amount` and `calculated_amount` are summed into the existing element (genuine aggregation, e.g. when a template legitimately produces two rows that happen to collapse to the same category/rate at header level).

All three call sites inside `_add_taxes_and_charges` (`On Net Total`, `On Previous Row Amount`, `On Previous Row Total`) are routed through the helper. `_add_empty_tax` continues to call `trade_tax.add` directly, because it is only invoked when no genuine tax row has been emitted yet.

## Tests

`test_sales_invoice.py` gains a new `TestHeaderTradeTaxDeduplication` class with seven cases:

- Identical duplicate collapses to one entry
- Thirteen identical duplicates collapse to one (reproduces the observed ERPNext pathology)
- Distinct rates remain separate (`19 %` vs `7 %`)
- Distinct category codes remain separate (`S` vs `AE`)
- Distinct type codes remain separate (`VAT` vs `SUR`)
- Distinct amounts under the same key are summed (`100 + 50 → 150`, `19 + 9.5 → 28.5`)
- Single-entry pass-through baseline

Local run:

```
$ bench --site <site> run-tests --app eu_einvoice --module eu_einvoice.european_e_invoice.custom.test_sales_invoice
...............
Ran 15 tests in 0.011s
OK
```

## Compatibility

- No public API changes.
- Existing callers of `_add_taxes_and_charges` see the same return value.
- The new helper reads `_value` / `_text` from drafthorse fields defensively, matching how the surrounding code already extracts values from `DecimalElement` / `StringElement`.
- Applies cleanly to `develop`, `version-15-hotfix`, and `version-16-hotfix` (identical code path).

## References

- EN 16931 rule BR-30 — "VAT breakdown"
- Schematron rules `CII-SR-045`, `BR-CO-18`
- Related upstream tracker for another hard-coded header artefact: #153 (SubjectCode "ABC")