### PR TITLE
feat: provide and import EN 16931 code lists

### DIFF
--- a/eu_einvoice/codelist/1001.gc
+++ b/eu_einvoice/codelist/1001.gc
@@ -1,0 +1,719 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>1001</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:1001</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:1001-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Remark" Use="optional">
+      <ShortName>Optional remark for the usage of this code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Request for payment</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit note related to goods or services</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit note related to goods or services</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metered services invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit note related to financial adjustments</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit note related to financial adjustments</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>102</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax notification</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>130</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoicing data sheet</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>202</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct payment valuation</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>203</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Provisional payment valuation</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>204</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment valuation</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>211</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interim application for payment</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>218</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Final payment request based on completion of work</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>219</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment request for completed units</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>261</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self billed credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>262</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consolidated credit note - goods and services</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>295</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price variation invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>296</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit note for price variation</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>308</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delcredere credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>325</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Proforma invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>326</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Partial invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>331</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commercial invoice which includes a packing list</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>380</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commercial invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>381</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>382</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commission note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>383</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>384</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Corrected invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>385</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consolidated invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>386</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prepayment invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>387</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hire invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>388</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>389</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self-billed invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>390</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delcredere invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>393</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Factored invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>394</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lease invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>395</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>396</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Factored credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>420</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Optical Character Reading (OCR) payment credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>456</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit advice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>457</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reversal of debit</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>458</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reversal of credit</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>471</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self-billed corrective invoice, invoice type, Corrected</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>472</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Factored Corrective Invoice, invoice type, Corrected</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>473</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self billed Factored corrective invoice, invoice type, Corrected</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>500</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self Prepayment invoice, invoice type, Original</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>501</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self billed factored invoice, invoice type, Original</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>502</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self billet factored Credit Note, Credit note type, Corrected</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>503</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prepayment credit note, credit note type, Corrected</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>527</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Self billed debit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>532</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Forwarder's credit note</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Credit Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>553</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Forwarder's invoice discrepancy report</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>575</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurer's invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>623</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Forwarder's invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>633</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Port charges documents</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>751</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice information for accounting purposes</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>780</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>817</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Claim notification</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>870</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consular invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>875</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Partial construction invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>876</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Partial final construction invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>877</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Final construction invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>935</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs invoice</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Invoice</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/1153.gc
+++ b/eu_einvoice/codelist/1153.gc
@@ -1,0 +1,6577 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>1153</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:1153</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:1153-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order acknowledgement document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Proforma invoice document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary credit identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract document addendum identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods declaration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit card number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Offer number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank's batch interbank transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank's individual interbank transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Despatch advice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drawing number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery schedule number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment identifier, consignee assigned</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Partial shipment identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Municipality assigned business registry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport contract document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Master label number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Despatch note document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Enquiry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Docket number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Civil action number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carrier's agent reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard Carrier Alpha Code (SCAC) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs valuation decision number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>End use authorization number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Anti-dumping case number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs tariff number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Declarant's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair estimate number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs decision request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sub-house bill of lading number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax payment identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quota number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transit (onward carriage) guarantee (bond) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs guarantee number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Replacing part number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Seller's catalogue number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Originator's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Declarant's Customs identity number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Importer reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export clearance instruction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Import clearance instruction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods declaration document identifier, Customs</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intra-plant routing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Stock keeping unit number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Text Element Identifier deletion reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Allotment identification (Air)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vehicle licence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Air cargo transfer manifest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cargo acceptance order reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US government agency number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipping unit identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Related document number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Addressee reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ATA carnet number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packaging unit identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Outerpackaging unit identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer material specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Principal reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collection advice document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Iron charge number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hot roll number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cold roll number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Railway wagon number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unique claims reference number of the sender</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loss/event number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Estimate order reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference number to previous message</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Banker's acceptance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Duty memo number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment transport charge number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Matured certificate of deposit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Analysis number/test number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Treaty number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Catastrophe number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bureau signing (statement reference)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company / syndicate reference 1</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company / syndicate reference 2</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ordering customer consignment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipowner's authorization number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inland transport order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container work order reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unique market reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Group accounting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Broker reference 1</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Broker reference 2</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lloyd's claims office reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Secure delivery terms and conditions agreement reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trader account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authorization for expense (AFE) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government agency reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Assembly number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Symbol number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commodity number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Eur 1 certificate number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer process specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Applicable instructions or standards</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registration number of previous Customs declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Post-entry reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery number (transport)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport route</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer's unit inventory number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product reservation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Project number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drawing list number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AER</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Project specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AES</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Primary reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Request for cancellation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier's control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipping note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Empty container bill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Non-negotiable maritime transport document number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Substitute air waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Despatch note (post parcels) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Airlines flight identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Through bill of lading number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cargo manifest number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bordereau number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export Control Commodity number (ECCN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marking/label reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tariff number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Replenishment purchase order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Immediate transportation no. for in bond movement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation exportation no. for in bond movement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Immediate exportation no. for in bond movement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Associated invoices</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Secondary Customs reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Account party's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beneficiary's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Second beneficiary's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Applicant's bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Issuing bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beneficiary's bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct payment valuation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct payment valuation request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quantity valuation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quantity valuation request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill of quantities number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment valuation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Situation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agreement to pay number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract party reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Account party's bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agent's bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agent's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Applicant's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dispute number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit rating agency's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Single transaction sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Application reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery verification certificate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Number of temporary importation document</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference number quoted on statement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sender's reference to the original message</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company issued equipment ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Domestic flight number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International flight number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Employer identification number of service bureau</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service group identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Member number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous member number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Scheme/plan number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous scheme/plan number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receiving party's member identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payroll number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packaging specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authority issued equipment identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Training flight number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fund code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Signal code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Major force program number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nomination number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Laboratory registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport contract reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payee's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payer's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Creditor's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debtor's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Joint venture reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chamber of Commerce registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wool identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wool tax reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meat processing establishment registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quarantine/treatment status reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Request for quote number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manual processing authority number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rate note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight Forwarder number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs release code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Compliance code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Department of transportation bond number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export establishment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AID</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certificate of conformity</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ministerial certificate of homologation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous delivery instruction number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Passport number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Common transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AII</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank's common transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer's individual transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank's individual transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer's common transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Individual transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product sourcing agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs transhipment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs preference inquiry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packing plant number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original certificate number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Processing plant number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slaughter plant number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Charge card account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Event reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport section reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Referred product for mechanical analysis</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Referred product for chemical analysis</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consolidated invoice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Part reference indicator in a drawing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. Code of Federal Regulations (CFR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchasing activity clause number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. Defense Federal Acquisition Regulation Supplement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agency clause number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Circular publication number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. Federal Acquisition Regulation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. General Services Administration Regulation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. Federal Information Resources Management Regulation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Paragraph</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special instructions number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Site specific procedures, terms, and conditions number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Master solicitation procedures, terms, and conditions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>U.S. Department of Veterans Affairs Acquisition Regulation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Military Interdepartmental Purchase Request (MIPR) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Foreign military sales number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Defense priorities allocation system priority rating</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wage determination number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard Industry Classification (SIC) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>End item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Federal supply schedule item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical document number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Suffix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container disposition order reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container prefix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment return reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment survey reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment survey report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment stuffing order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vehicle Identification Number (VIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government bill of lading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ordering customer's second reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct debit reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meter reading at the beginning of the delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meter reading at the end of delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Replenishment purchase order range start number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Third bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Action authorization number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Appropriation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product change authority number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General cargo consignment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Catalogue sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Forwarding order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment survey reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lease contract reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport costs reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment stripping order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prior policy number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AKZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Policy number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Procurement budget number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Domestic inventory management code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer reference number assigned to previous balance of</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous credit advice reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reporting form number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authorization number for exception to dangerous goods</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dangerous goods security number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dangerous goods transport licence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous rental agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Next rental agreement reason number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignee's invoice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message batch number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous delivery schedule number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Physical inventory recount reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receiving advice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returnable container reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returns notice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales forecast number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous tax control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AGERD (Aerospace Ground Equipment Requirement Data) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registered capital reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard number of inspection document</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Model</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial management reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NOTIfication for COLlection number (NOTICOL)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous request for metered reading reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Next rental agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference number of a request for metered reading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hastening number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AME</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair data request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consumption data request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Profile number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government quality assurance and control level Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment plan reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Replaced meter unit number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AML</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Replenishment purchase order range end number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurer assigned reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canadian excise entry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Premium rate table</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advise through bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US, Department of Transportation bond surety code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US, Food and Drug Administration establishment indicator</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US, Federal Communications Commission (FCC) import</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods and Services Tax identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Integrated logistic support cross reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Department number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's catalogue number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial settlement party's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard's version number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pipeline number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Account servicing bank's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Completed units payment request reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment in advance request reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AND</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Parent file</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sub file</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CAD file layer convention</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical regulation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plot file</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>File conversion journal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authorization number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference number assigned by third party</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Deposit reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Named bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drawee's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case of need party's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collecting bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Remitting bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Principal's bank reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Presenting bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignee's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receiving bank's authorization number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clearing reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sending bank's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary payment reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accounting file reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sender's file reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receiver's file reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Source document internal reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Principal's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Calendar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work shift</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work breakdown structure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organisation breakdown structure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work task charge number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Functional work group</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work team</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Department</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statement of work</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work package</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Planning package</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cost account</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation Control Number (TCN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Constraint notation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ETERMS reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AOZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Implementation version number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accounts receivable number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Incorporated legal reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment instalment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment owner reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cedent's claim number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reinsurer's claim number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price/sales catalogue response reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General purpose message reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoicing data sheet reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>API</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inventory report reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ceiling formula reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price variation formula reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference to account servicing bank's message</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Party sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchaser's request reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contractor request reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accident reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commercial account summary reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract breakdown reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contractor registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Applicable coefficient identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special budget account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authorisation for repair reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturer defined repair rates reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original submitter log number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original submitter, parent Data Maintenance Request (DMR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original submitter, child Data Maintenance Request (DMR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entry point assessment log number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entry point assessment log number, parent DMR</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entry point assessment log number, child DMR</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Data structure tag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Central secretariat log number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Central secretariat log number, parent Data Maintenance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Central secretariat log number, child Data Maintenance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International assessment log number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International assessment log number, parent Data</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International assessment log number, child Data Maintenance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Status report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message design group number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US Customs Service (USCS) entry code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beginning job sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sender's clause number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dun and Bradstreet Canada's 8 digit Standard Industrial</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Activite Principale Exercee (APE) identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dun and Bradstreet US 8 digit Standard Industrial</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nomenclature Activity Classification Economy (NACE)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Norme Activite Francaise (NAF) identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registered contractor activity type</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statistic Bundes Amt (SBA) identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>State or province assigned entity identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Institute of Security and Future Market Development (ISFMD)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>File identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bankruptcy procedure number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National government business identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prior Data Universal Number System (DUNS) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Companies Registry Office (CRO) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Costa Rican judicial number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Numero de Identificacion Tributaria (NIT)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Patron number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registro Informacion Fiscal (RIF) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registro Unico de Contribuyente (RUC) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tokyo SHOKO Research (TSR) business identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Personal identity card number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Systeme Informatique pour le Repertoire des ENtreprises</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Systeme Informatique pour le Repertoire des ETablissements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Publication issue number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original filing number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document page identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Public filing registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Regiristo Federal de Contribuyentes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Social security number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document volume number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ART</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Book number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Stock exchange company identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Imputation account</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial phase reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical phase reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prior contractor registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Stock adjustment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dispensation reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Investment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Assuming company</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Budget chapter</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Duty free products security number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Duty free products receipt authorisation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Party information message reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Formal statement reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Proof of delivery reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier's credit claim reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Picture of actual product</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Picture of a generic product</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trading partner identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prior trading partner identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Password</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Formal report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fund account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safe custody number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Master account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Group reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accounting transmission number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product data file number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cadastro Geral do Contribuinte (CGC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Foreign resident identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CD-ROM</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Physical medium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial cancellation reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase for export Customs agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Judgment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Secretariat number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous banking status message reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Last received banking status message reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank's documentary procedure reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer's documentary procedure reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safe deposit box number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receiving Bankgiro number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sending Bankgiro number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bankgiro reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guarantee number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collection instrument number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Converted Postgiro number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cost centre alignment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kamer Van Koophandel (KVK) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Institut Belgo-Luxembourgeois de Codification (IBLC) number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>External object reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exceptional transport authorisation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clave Unica de Identificacion Tributaria (CUIT)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registro Unico Tributario (RUT)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Flat rack container bundle identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment acceptance order reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment release order reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship's stay reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authorization to meet competition number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Place of positioning reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Party reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Issued prescription identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collection reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Travel service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment stock contract</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Importer's letter of credit reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Performed prescription identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Image reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Proposed purchase order reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Application for financial support reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturing quality agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Software editor reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Software reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Software quality reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consolidated orders' reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs binding ruling number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs non-binding ruling number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery route reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net area supplier reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Time series reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Connecting point to central grid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marketing plan identification number (MPIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entity reference number, previous</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Standard Industrial Classification (ISIC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs pre-approval ruling number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Account payable number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>First financial institution's transaction reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product characteristics directory</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier's customer reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inventory report request number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metering point</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Passenger reservation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slaughterhouse approval number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meat cutting plant approval number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer travel service identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export control classification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Broker reference 3</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods item information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dangerous Goods information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pilotage services exemption number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Person registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Place of packing approval number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original Mandate Reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mandate Reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reservation station indentifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unique goods shipment identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Framework Agreement Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hash value</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Movement reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Economic Operators Registration and Identification Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Local Reference Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rate code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Air waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary credit amendment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advising bank's reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cost centre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work item quantity determination</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internal data process number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Category of work reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Policy form number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net area</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service provider</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Error position</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service category reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Connected location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Related party</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Latest accounting entry record reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accounting entry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document reference, original</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hygienic Certificate number, national</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Administrative Reference Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pick-up sheet number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Phone number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's fund number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company trading account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reserved goods identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Handling and movement reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instruction to despatch reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instruction for returns number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metered services consumption report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order status enquiry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Firm booking reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product inquiry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Split delivery number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service relation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Serial shipping container code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Test specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport status report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tooling contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Formula reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pre-agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product certification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product specification reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payroll deduction advice reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TRACES party identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AXU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Block Stowage Reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beginning meter reading actual</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bid number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beginning meter reading estimated</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>House bill of lading number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill of lading number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment identifier, carrier assigned</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Blanket order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Broker or sales office number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Batch number/lot number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BTP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Battery and accumulator producer registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Blended with number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IATA Cargo Agent CASS Address number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Matching of entries, balanced</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entry flagging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Matching of entries, unbalanced</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document reference, internal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Value Added Tax identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cost accounting document</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Grid operator's customer reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CBA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ticket control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CBB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order shipment grouping reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ceding company</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit letter number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CFE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignee's further order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CFF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Animal farm licence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CFO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignor's further order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignee's order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer catalogue number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cheque number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CKN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Checking number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit memo number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CMR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Road consignment note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carrier's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CNO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Charges note document attachment indicator</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>COF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Call off order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Condition of purchase document number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CRN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport means journey identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Condition of sale document number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Team assignment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment identifier, consignor assigned</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container operators reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cooperation contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Deferment approval number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's debtor number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Distributor invoice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dock receipt number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ending meter reading actual</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Embargo permit number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ending meter reading estimated</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EEP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Electrical and electronic equipment producer registration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Employer's identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Embargo number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ER</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container/equipment receipt number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ERN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exporter's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Excess transportation number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export permit identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fiscal number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment identifier, freight forwarder assigned</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>File line identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FLW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Flow reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight bill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Foreign exchange</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Final sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Free zone identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>File version number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Foreign exchange contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard's number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard's code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GDN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General declaration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Harmonised system number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HWB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>House waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internal vendor number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>In bond number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ICA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IATA cargo agent code number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ICE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurance certificate reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ICO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurance contract reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>II</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Initial sample inspection report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internal order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediary broker</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interchange number new</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interchange number old</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Import permit identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice number suffix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internal customer number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice document identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Job number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ending job sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipping label serial number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loading authorisation identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lower number in range</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lockbox</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Letter of credit number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document line identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Load planning number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LRC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reservation office identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bar coded label serial number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship notice/manifest number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Master bill of lading number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturer's part number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meter unit number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturing order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message recipient</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MRN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mailing reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message sender</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MSS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturer's material safety data sheet number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MWB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Master air waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>North American hazardous goods classification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nota Fiscal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Current invoice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous invoice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order document identifier, buyer assigned</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original purchase order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payer's financial institution account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Production code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promotion deal number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plant number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prime contractor contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price list version number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packing list number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price list number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>POR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase order response number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase order change number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price quote number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase order number suffix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prior purchase order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payee's financial institution account number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Remittance advice number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rail/road routing code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RCN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Railway consignment note number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Release number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>REN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment receipt identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payer's financial institution transit routing No.(ACH</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payee's financial institution transit routing No.</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales person number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales region number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales department number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Serial number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SEA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Allocated seat</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship from</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous highest schedule number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SID (Shipper's identifying number for shipment)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales office number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment seal identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Scan line</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment sequence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sellers reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Station reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Swap order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trucker's bill of lading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TCR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Terminal operator's consignment reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Telex message number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transfer number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TIR carnet number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport instruction number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax exemption licence number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transaction reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Test report number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Upper number of range</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ultimate customer's reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UCN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unique consignment reference number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Nations Dangerous Goods identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ultimate customer's order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>URI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Uniform Resource Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>VAT registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VGR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment gross mass verification reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vessel identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order number (vendor)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Voyage number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VOR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport equipment gross mass verification order reference</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor product number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor ID number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor order number suffix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Motor vehicle identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Voucher number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehouse entry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Weight agreement number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Well number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehouse receipt number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehouse storage location number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rail waybill number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company/place registration number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cargo control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous cargo control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined reference number</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/5305.gc
+++ b/eu_einvoice/codelist/5305.gc
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>5305</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:5305</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:5305-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Remark" Use="optional">
+      <ShortName>Optional remark for the usage of this code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>S</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard rate</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Standard rate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Z</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Zero rated goods</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Zero rated goods</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt from tax</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Exempt from tax</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>VAT Reverse charge</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>VAT reverse charge</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>VAT exempt for EEA intra-community supply of goods and services</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>VAT exempt for intra community supply of goods</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Free export item, tax not charged</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Free export item, tax not charged</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>O</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service outside scope of tax</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Services outside scope of tax</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canary Islands general indirect tax</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Canary Islands General Indirect Tax</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax for production, services and importation in Ceuta and Melilla</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Liable for IPSI</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Allowance.gc
+++ b/eu_einvoice/codelist/Allowance.gc
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Allowance</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Allowance</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Allowance-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bonus for works ahead of schedule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Other bonus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturer’s consumer discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Due to military status</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Due to work accident</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special agreement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Production error discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>New outlet discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sample discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>End-of-range discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Incoterm discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Point of sales threshold allowance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Material surcharge/deduction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>100</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special rebate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>102</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fixed long term</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>103</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Temporary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>104</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>105</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Yearly turnover</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Charge.gc
+++ b/eu_einvoice/codelist/Charge.gc
@@ -1,0 +1,1457 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Charge</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Charge</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Charge-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advertising</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Telecommunication</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical modification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Job-order production</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Outlays</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Off-premises</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional processing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Attesting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Acceptance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rush delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special construction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Airport facilities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Concession</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Compulsory storage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fuel removal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Into plane</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Overtime</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tooling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Miscellaneous</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional packaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dunnage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Containerisation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carton packing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hessian wrapped</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Polyethylene wrap packing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Miscellaneous treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Enamelling treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Heat treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plating treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Painting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Polishing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Priming</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Preservation treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fitting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consolidation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill of lading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Airbag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transfer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slipsheet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Binding</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair or replacement of broken returnable package</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Efficient logistics</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Merchandising</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product mix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Other services</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pick-up</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chronic illness</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>New product introduction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Diversion</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Disconnect</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Distribution</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Handling of hazardous cargo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rents and leases</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Location differential</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Aircraft refueling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fuel shipped into storage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cash on delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Small order processing service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clerical or administrative services</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guarantee</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collection and recycling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Copyright fee collection</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AES</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Veterinary inspection service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pensioner service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicine free pass holder</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Environmental protection service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Environmental clean-up service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National cheque processing service outside account area</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National payment service outside account area</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National payment service within account area</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Adjustments</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authentication</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cataloguing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cartage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certificate of conformance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certificate of origin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cutting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consular service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer collection</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payroll payment service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cash transportation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Home banking service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bilateral agreement service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurance brokerage service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cheque generation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Preferential merchandising location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crane</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special colour service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sorting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Battery collection and recycling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product take back fee</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quality control released</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quality control held</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quality control embargo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Car loading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cleaning</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cigarette stamping</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Count and recount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Layout/design</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Assortment allowance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Driver assigned unloading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debtor bound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dealer allowance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Allowance transferable to the consumer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Growth of business</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Introduction allowance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Multi-buy promotion</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Partnership</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Return handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Minimum order not fulfilled charge</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Point of sales threshold allowance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wholesaling discount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary credits transfer commission</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Engraving</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Expediting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ER</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exchange rate guarantee</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fabrication</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight equalization</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight extraordinary handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Freight service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Filling/handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Grinding</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hose</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hoisting and hauling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Installation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Installation and warranty</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ID</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inside delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inspection</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Installation and training</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoicing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Koshering</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carrier count</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Labelling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Labour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair and return</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legalisation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mounting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mail invoice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ML</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mail invoice to each location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Non-returnable containers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Outside cable connectors</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice with shipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Phosphatizing (steel treatment)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Palletizing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PRV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price variation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repacking</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returnable container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Restocking</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Re-delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Refurbishing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rail wagon hire</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loading</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Salvaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shipping and handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special packaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Stamping</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignee unload</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shrink-wrap</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special finish</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Set-up</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tank renting</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Testing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation - third party billing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation by vendor</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>V1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drop yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>V2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drop dock</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehousing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Combine all same day shipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Split pick-up</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Country.gc
+++ b/eu_einvoice/codelist/Country.gc
@@ -1,0 +1,2041 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Country</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Country</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Country-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Andorra</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Arab Emirates (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Afghanistan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Antigua and Barbuda</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Anguilla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Albania</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Armenia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Angola</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Antarctica</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Argentina</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>American Samoa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Austria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Australia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Aruba</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Åland Islands</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Azerbaijan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bosnia and Herzegovina</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Barbados</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bangladesh</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Belgium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Burkina Faso</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulgaria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bahrain</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Burundi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Benin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Barthélemy</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bermuda</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Brunei Darussalam</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bolivia (Plurinational State of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bonaire, Sint Eustatius and Saba</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Brazil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bahamas (The)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bhutan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bouvet Island</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Botswana</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Belarus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Belize</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canada</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cocos (Keeling) Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Congo (the Democratic Republic of the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Central African Republic (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Congo (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Switzerland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Côte d'Ivoire</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cook Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cameroon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>China</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Colombia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Costa Rica</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cuba</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cabo Verde</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Curaçao</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Christmas Island</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cyprus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Czechia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Germany</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Djibouti</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Denmark</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dominica</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dominican Republic (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Algeria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ecuador</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Estonia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Egypt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Western Sahara*</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ER</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Eritrea</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ES</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Spain</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ethiopia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fiji</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Falkland Islands (the) [Malvinas]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Micronesia (Federated States of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Faroe Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Gabon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Kingdom of Great Britain and Northern Ireland (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Grenada</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Georgia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French Guiana</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guernsey</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ghana</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Gibraltar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Greenland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Gambia (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guinea</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guadeloupe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equatorial Guinea</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Greece</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>South Georgia and the South Sandwich Islands</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guatemala</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guam</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guinea-Bissau</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guyana</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hong Kong</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Heard Island and McDonald Islands</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Honduras</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Croatia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Haiti</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hungary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ID</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Indonesia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ireland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Israel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Isle of Man</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>India</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British Indian Ocean Territory (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Iraq</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Iran (Islamic Republic of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Iceland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Italy</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jersey</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jamaica</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jordan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Japan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kenya</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kyrgyzstan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cambodia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kiribati</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Comoros (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Kitts and Nevis</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Korea (the Democratic People's Republic of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Korea (the Republic of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kuwait</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cayman Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kazakhstan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lao People's Democratic Republic (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lebanon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Lucia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Liechtenstein</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sri Lanka</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Liberia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lesotho</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lithuania</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Luxembourg</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Latvia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Libya</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Morocco</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Monaco</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Moldova (the Republic of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ME</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Montenegro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Martin (French part)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Madagascar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marshall Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>North Macedonia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ML</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mali</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Myanmar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mongolia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Macao</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Northern Mariana Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Martinique</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mauritania</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Montserrat</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Malta</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mauritius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Maldives</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Malawi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mexico</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Malaysia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mozambique</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Namibia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>New Caledonia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Niger (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Norfolk Island</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nigeria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nicaragua</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Netherlands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Norway</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nepal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nauru</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Niue</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>New Zealand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oman</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Panama</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Peru</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French Polynesia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Papua New Guinea</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Philippines (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pakistan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Poland</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Pierre and Miquelon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pitcairn</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Puerto Rico</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Palestine, State of</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Portugal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Palau</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Paraguay</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Qatar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Réunion</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Romania</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Serbia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Russian Federation (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rwanda</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saudi Arabia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Solomon Islands</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Seychelles</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sudan (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sweden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Singapore</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Helena, Ascension and Tristan da Cunha</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slovenia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Svalbard and Jan Mayen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slovakia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sierra Leone</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>San Marino</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Senegal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Somalia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Suriname</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>South Sudan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sao Tome and Principe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>El Salvador</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sint Maarten (Dutch part)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Syrian Arab Republic (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Eswatini</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Turks and Caicos Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French Southern Territories (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Togo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Thailand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tajikistan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tokelau</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Timor-Leste</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Turkmenistan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tunisia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tonga</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Türkiye</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trinidad and Tobago</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tuvalu</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Taiwan (Province of China)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tanzania, the United Republic of</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ukraine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Uganda</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United States Minor Outlying Islands (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>US</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United States of America (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Uruguay</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Uzbekistan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Holy See (the)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Vincent and the Grenadines</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Venezuela (Bolivarian Republic of)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Virgin Islands (British)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Virgin Islands (U.S.)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Viet Nam</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vanuatu</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wallis and Futuna</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Samoa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Yemen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mayotte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>South Africa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Zambia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Zimbabwe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>1A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kosovo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Kingdom (Northern Ireland)</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/EAS.gc
+++ b/eu_einvoice/codelist/EAS.gc
@@ -1,0 +1,851 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>EAS</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:EAS</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:EAS-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0002</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>System Information et Repertoire des Entreprise et des Etablissements: SIRENE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0007</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organisationsnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0009</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIRET-CODE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0037</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LY-tunnus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0060</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Data Universal Numbering System (D-U-N-S Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0088</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EAN Location Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0096</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Danish Business Authority - P-number (DK:P)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0097</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FTI - Ediforum Italia, (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0106</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vereniging van Kamers van Koophandel en Fabrieken in Nederland (Association of
+Chambers of Commerce and Industry in the Netherlands), Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0130</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Directorates of the European Commission</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0135</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIA Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0142</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SECETI Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0147</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard Company Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0151</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Australian Business Number (ABN) Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0154</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Identification number of economic subjects: (ICO)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0158</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Identification number of economic subject (ICO) Act on State Statistics of 29 November 2001, § 27</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0170</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Teikoku Company Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0177</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Odette International Limited</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0183</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Numéro d'identification suisse des enterprises (IDE), Swiss Unique Business Identification Number (UIDB)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0184</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DIGSTORG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0188</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Corporate Number of The Social Security and Tax Number System</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0190</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dutch Originator's Identification Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0191</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Centre of Registers and Information Systems of the Ministry of Justice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0192</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Enhetsregisteret ved Bronnoysundregisterne</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0193</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UBL.BE party identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0194</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>KOIOS Open Technical Dictionary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0195</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Singapore UEN identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0196</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kennitala - Iceland legal id for individuals and legal entities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0198</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ERSTORG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0199</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Global legal entity identifier (GLEIF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0200</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legal entity code (Lithuania)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0201</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Codice Univoco Unità Organizzativa iPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0202</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Indirizzo di Posta Elettronica Certificata</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0203</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>eDelivery Network Participant identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0204</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Leitweg-ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0205</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CODDEST</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0208</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Numero d'entreprise / ondernemingsnummer / Unternehmensnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0209</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 identification keys</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0210</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CODICE FISCALE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0211</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>PARTITA IVA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0212</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finnish Organization Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0213</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finnish Organization Value Add Tax Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0215</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net service ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0216</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OVTcode</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0217</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Netherlands Chamber of Commerce and Industry establishment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0218</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unified registration number (Latvia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0221</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The registered number of the qualified invoice issuer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0225</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FRCTC ELECTRONIC ADDRESS</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0230</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National e-Invoicing Framework</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0235</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UAE Tax Identification Number (TIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0240</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Register of legal persons (in French : Répertoire des personnes morales)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0242</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OpenPeppol Service Provider Identification Scheme (SPIS)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0244</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax Identification (Tax ID), Nigeria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0245</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax identification number (DIČ, Slovakia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0246</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>German Electronic Business Address</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0248</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oman Value Added Tax Identification Number (VATIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9910</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hungary VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9913</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business Registers Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9914</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Österreichische Umsatzsteuer-Identifikationsnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9915</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Österreichisches Verwaltungs bzw.
+Organisationskennzeichen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9918</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SOCIETY FOR WORLDWIDE INTERBANK FINANCIAL, TELECOMMUNICATION S.W.I.F.T</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9919</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kennziffer des Unternehmensregisters</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9920</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agencia Española de Administración Tributaria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9922</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Andorra VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9923</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Albania VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9924</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bosnia and Herzegovina VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9925</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Belgium VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9926</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulgaria VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9927</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Switzerland VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9928</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cyprus VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9929</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Czech Republic VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9930</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Germany VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9931</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Estonia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9932</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Kingdom VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9933</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Greece VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9934</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Croatia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9935</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ireland VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9936</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Liechtenstein VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9937</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lithuania VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9938</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Luxemburg VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9939</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Latvia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9940</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Monaco VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9941</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Montenegro VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9942</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Macedonia, the former Yugoslav Republic of VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9943</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Malta VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9944</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Netherlands VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9945</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Poland VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9946</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Portugal VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9947</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Romania VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9948</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Serbia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9949</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slovenia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9950</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slovakia VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9951</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>San Marino VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9952</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Turkey VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9953</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Holy See (Vatican City State) VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9957</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French VAT number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9959</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Employer Identification Number (EIN, USA)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>O.F.T.P. (ODETTE File Transfer Protocol)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>X.400 address for mail text</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AS2 exchange</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>File Transfer Protocol</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Electronic mail (SMPT)</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/ICD.gc
+++ b/eu_einvoice/codelist/ICD.gc
@@ -1,0 +1,1977 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>ICD</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:ICD</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:ICD-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0002</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>System Information et Repertoire des Entreprise et des Etablissements: SIRENE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0003</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Codification Numerique des Etablissments Financiers En Belgique</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0004</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NBS/OSI NETWORK</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0005</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>USA FED GOV OSI NETWORK</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0006</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>USA DOD OSI NETWORK</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0007</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organisationsnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0008</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LE NUMERO NATIONAL</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0009</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIRET-CODE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0010</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organizational Identifiers for Structured Names under ISO 9541 Part 2</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0011</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Code Designator for the Identification of OSI-based, Amateur Radio Organizations, Network Objects and Application Services.</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0012</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Computer Manufacturers Association: ECMA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0013</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>VSA FTP CODE (FTP = File Transfer Protocol)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0014</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NIST/OSI Implememts' Workshop</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0015</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Electronic Data Interchange: EDI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0016</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EWOS Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0017</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>COMMON LANGUAGE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0018</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SNA/OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0019</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Air Transport Industry Services Communications Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0020</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Laboratory for Particle Physics: CERN</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0021</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SOCIETY FOR WORLDWIDE INTERBANK FINANCIAL, TELECOMMUNICATION S.W.I.F.T.</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0022</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OSF Distributed Computing Object Identification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0023</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nordic University and Research Network: NORDUnet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0024</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Digital Equipment Corporation: DEC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0025</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OSI ASIA-OCEANIA WORKSHOP</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0026</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NATO ISO 6523 ICDE coding scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0027</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Aeronautical Telecommunications Network (ATN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0028</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Standard ISO 6523</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0029</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The All-Union Classifier of Enterprises and Organisations</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0030</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AT&amp;T/OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0031</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EDI Partner Identification Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0032</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Telecom Australia</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0033</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>S G W OSI Internetwork</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0034</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reuter Open Address Standard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0035</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ISO 6523 - ICD</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0036</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TeleTrust Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0037</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LY-tunnus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0038</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Australian GOSIP Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0039</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The OZ DOD OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0040</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unilever Group Companies</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0041</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Citicorp Global Information Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0042</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DBP Telekom Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0043</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>HydroNETT</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0044</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Thai Industrial Standards Institute (TISI)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0045</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ICI Company Identification System</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0046</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FUNLOC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0047</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BULL ODI/DSA/UNIX Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0048</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OSINZ</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0049</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Auckland Area Health</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0050</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Firmenich</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0051</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AGFA-DIS</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0052</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Society of Motion Picture and Television Engineers (SMPTE)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0053</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Migros_Network M_NETOPZ</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0054</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ISO6523 - ICDPCR</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0055</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Energy Net</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0056</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nokia Object Identifiers (NOI)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0057</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Saint Gobain</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0058</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Siemens Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0059</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DANZNET</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0060</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Data Universal Numbering System (D-U-N-S Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0061</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SOFFEX OSI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0062</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>KPN OVN</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0063</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ascomOSINet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0064</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UTC: Uniforme Transport Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0065</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SOLVAY OSI CODING</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0066</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Roche Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0067</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ZellwegerOSINet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0068</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intel Corporation OSI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0069</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SITA Object Identifier Tree</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0070</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DaimlerChrysler Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0071</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LEGO /OSI NETWORK</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0072</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NAVISTAR/OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0073</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ICD Formatted ATM address</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0074</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ARINC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0075</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Alcanet/Alcatel-Alsthom Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0076</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sistema Italiano di Identificazione di ogetti gestito da UNINFO</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0077</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sistema Italiano di Indirizzamento di Reti OSI Gestito da UNINFO</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0078</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mitel terminal or switching equipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0079</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ATM Forum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0080</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UK National Health Service Scheme, (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0081</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International NSAP</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0082</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Norwegian Telecommunications Authority's, NTA'S, EDI, identifier scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0083</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advanced Telecommunications Modules Limited, Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0084</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Athens Chamber of Commerce &amp; Industry Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0085</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Swiss Chambers of Commerce Scheme (EDIRA) compliant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0086</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United States Council for International Business (USCIB) Scheme, (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0087</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National Federation of Chambers of Commerce &amp; Industry of Belgium, Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0088</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EAN Location Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0089</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Association of British Chambers of Commerce Ltd. Scheme, (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0090</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internet IP addressing - ISO 6523 ICD encoding</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0091</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cisco Sysytems / OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0093</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Revenue Canada Business Number Registration (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0094</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DEUTSCHER INDUSTRIE- UND HANDELSTAG (DIHT) Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0095</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hewlett - Packard Company Internal AM Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0096</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Danish Business Authority - P-number (DK:P)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0097</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FTI - Ediforum Italia, (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0098</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CHAMBER OF COMMERCE TEL AVIV-JAFFA Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0099</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Siemens Supervisory Systems Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0100</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>PNG_ICD Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0101</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>South African Code Allocation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0102</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>HEAG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0104</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BT - ICD Coding System</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0105</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Portuguese Chamber of Commerce and Industry Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0106</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vereniging van Kamers van Koophandel en Fabrieken in Nederland (Association of Chambers of Commerce and Industry in the Netherlands), Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0107</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Association of Swedish Chambers of Commerce and Industry Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0108</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Australian Chambers of Commerce and Industry Scheme (EDIRA compliant)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0109</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BellSouth ICD AESA (ATM End System Address)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0110</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bell Atlantic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0111</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0112</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ISO register for Standards producing Organizations</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0113</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OriginNet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0114</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Check Point Software Technologies</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0115</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pacific Bell Data Communications Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0116</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>PSS Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0117</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>STENTOR-ICD CODING SYSTEM</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0118</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ATM-Network ZN'96</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0119</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>MCI / OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0120</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advantis</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0121</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Affable Software Data Interchange Codes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0122</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BB-DATA GmbH</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0123</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BASF Company ATM-Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0124</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IOTA Identifiers for Organizations for Telecommunications Addressing using the ICD system format defined in ISO/IEC 8348</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0125</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Henkel Corporate Network (H-Net)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0126</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GTE/OSI Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0127</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dresdner Bank Corporate Network</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0128</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BCNR (Swiss Clearing Bank Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0129</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>BPI (Swiss Business Partner Identification) code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0130</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Directorates of the European Commission</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0131</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Code for the Identification of National Organizations</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0132</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certicom Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0133</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TC68 OID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0134</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Infonet Services Corporation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0135</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIA Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0136</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cable &amp; Wireless Global ATM End-System Address Plan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0137</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Global AESA scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0138</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>France Telecom ATM End System Address Plan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0139</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Savvis Communications AESA:.</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0140</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Toshiba Organizations, Partners, And Suppliers' (TOPAS) Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0141</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NATO Commercial and Government Entity system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0142</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SECETI Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0143</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EINESTEINet AG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0144</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DoDAAC (Department of Defense Activity Address Code)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0145</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DGCP (Direction Générale de la Comptabilité Publique)administrative accounting identification scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0146</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DGI (Direction Générale des Impots) code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0147</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard Company Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0148</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ITU (International Telecommunications Union)Data Network Identification Codes (DNIC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0149</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Global Business Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0150</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Madge Networks Ltd- ICD ATM Addressing Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0151</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Australian Business Number (ABN) Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0152</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Edira Scheme Identifier Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0153</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Concert Global Network Services ICD AESA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0154</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Identification number of economic subjects: (ICO)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0155</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Global Crossing AESA (ATM End System Address)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0156</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AUNA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0157</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ATM interconnection with the Dutch KPN Telecom</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0158</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Identification number of economic subject (ICO) Act on State Statistics of 29 November 2'001, § 27</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0159</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACTALIS Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0160</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GTIN - Global Trade Item Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0161</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ECCMA Open Technical Directory</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0162</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CEN/ISSS Object Identifier Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0163</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US-EPA Facility Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0164</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TELUS Corporation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0165</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FIEIE Object identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0166</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Swissguide Identifier Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0167</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Priority Telecom ATM End System Address Plan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0168</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vodafone Ireland OSI Addressing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0169</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Swiss Federal Business Identification Number. Central Business names Index (zefix) Identification Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0170</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Teikoku Company Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0171</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Luxembourg CP &amp; CPS (Certification Policy and Certification Practice Statement) Index</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0172</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Project Group “Lists of Properties” (PROLIST®)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0173</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>eCI@ss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0174</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>StepNexus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0175</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Siemens AG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0176</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Paradine GmbH</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0177</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Odette International Limited</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0178</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Route1 MobiNET</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0179</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Penango Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0180</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lithuanian military PKI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0183</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Numéro d'identification suisse des enterprises (IDE), Swiss Unique Business Identification Number (UIDB)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0184</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>DIGSTORG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0185</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Perceval Object Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0186</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TrustPoint Object Identifiers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0187</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Amazon Unique Identification Scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0188</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Corporate Number of The Social Security and Tax Number System</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0189</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Business Identifier (EBID)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0190</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organisatie Indentificatie Nummer (OIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0191</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Company Code (Estonia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0192</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organisasjonsnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0193</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UBL.BE Party Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0194</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>KOIOS Open Technical Dictionary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0195</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Singapore Nationwide E-lnvoice Framework</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0196</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Icelandic identifier - Íslensk kennitala</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0197</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>APPLiA Pl Standard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0198</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ERSTORG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0199</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legal Entity Identifier (LEI)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0200</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legal entity code (Lithuania)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0201</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Codice Univoco Unità Organizzativa iPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0202</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Indirizzo di Posta Elettronica Certificata</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0203</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>eDelivery Network Participant identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0204</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Leitweg-ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0205</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CODDEST</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0206</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registre du Commerce et de l’Industrie : RCI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0207</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>PiLog Ontology Codification Identifier (POCI)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0208</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Numero d'entreprise / ondernemingsnummer / Unternehmensnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0209</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 identification keys</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0210</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CODICE FISCALE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0211</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>PARTITA IVA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0212</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finnish Organization Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0213</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finnish Organization Value Add Tax Identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0214</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tradeplace TradePI Standard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0215</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net service ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0216</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OVTcode</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0217</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Netherlands Chamber of Commerce and Industry establishment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0218</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unified registration number (Latvia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0219</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Taxpayer registration code (Latvia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0220</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The Register of Natural Persons (Latvia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0221</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>The registered number of the qualified invoice issuer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0222</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metadata Registry Support</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0223</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EU based company</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0224</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FTCTC CODE ROUTAGE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0225</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FRCTC ELECTRONIC ADDRESS</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0226</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FRCTC Particulier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0227</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NON - EU based company</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0228</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Répertoire des Entreprises et des Etablissements (RIDET)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0229</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>T.A.H.I.T.I (traitement automatique hiérarchisé des institutions de Tahiti et des îles)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0230</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National e-Invoicing Framework</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0231</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Single taxable company (France)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0232</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NOBB product number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0233</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Elnummer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0234</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Toimitusosoite ID</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0235</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UAE Tax Identification Number (TIN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0236</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ToimipaikkalD</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0237</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CPR (Danish person civil registration number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0238</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plateforme.s agréée.s à la facturation électronique (PPF/PDP)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0239</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EAEU</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0240</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Register of legal persons (in French : Répertoire des personnes morales)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0241</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hitachi Rail</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0242</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>OpenPeppol Service Provider Identification Scheme (SPIS)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0243</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business Partner Number (Catena-X)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0244</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax Identification (Tax ID), Nigeria</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0245</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax identification number (DIČ, Slovakia)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0246</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>German Electronic Business Address</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0247</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Name unknown</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>0248</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oman Value Added Tax Identification Number (VATIN)</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Item.gc
+++ b/eu_einvoice/codelist/Item.gc
@@ -1,0 +1,1513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Item</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Item</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Item-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product version number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Assembly</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>HIBC (Health Industry Bar Code)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cold roll number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hot roll number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slab number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Software revision number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal Product Code) Consumer package code (1-5-5)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal Product Code) Consumer package code (1-5-5-</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sample number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pack number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal Product Code) Shipping container code (1-2-</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal Product Code)/EAN (European article number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal Product Code) suffix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>State label code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Heat number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Coupon number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Resource number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Work task number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price look up number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NSN (North Atlantic Treaty Organization Stock Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Refined product code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exhibit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>End item</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Federal supply classification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Engineering data list</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Milestone event number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lot number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National drug code 4-4-2 format</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National drug code 5-3-2 format</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National drug code 5-4-1 format</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National drug code 5-4-2 format</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National drug code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Part number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Local Stock Number (LSN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Next higher assembly number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Data category</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special material identification code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Locally assigned control number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's colour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's part number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Variable measure product code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial phase</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract breakdown</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Technical phase</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dye lot number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Daily statement of activities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Periodical statement of activities within a bilaterally</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Calendar week statement of activities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Calendar month statement of activities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original equipment number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Industry commodity code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commodity grouping</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Colour number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drawing revision number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drawing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Engineering change level</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Material code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EMD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EMDN (European Medical Device Nomenclature)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Article Numbering Association (EAN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fish species</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's internal product group code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GMN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Global model number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National product group code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Harmonised system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ISBN (International Standard Book Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ISSN (International Standard Serial Number)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's style number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's size code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Machine number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Manufacturer's (producer's) article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Model number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product/service identification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Batch number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Part number description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchaser's order line number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase order number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PPI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Phytosanitary Passport identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promotional variant number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Buyer's qualifier for size</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returnable container number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Release number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Run number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Record keeping of model year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier's article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard group of products (mixed assortment)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SKU (Stock keeping unit)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Serial number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>RSK number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IFLS (Institut Francais du Libre Service) 5 digit product</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IFLS (Institut Francais du Libre Service) 9 digit product</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 Global Trade Item Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EDIS (Energy Data Identification System)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slaughter number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Official animal number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Harmonized tariff schedule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier's supplier article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>46 Level DOT Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Airline Tariff 6D</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Title 49 Code of Federal Regulations</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Civil Aviation Administration code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hazardous Materials ID DOT</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Endorsement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Air Force Regulation 71-4</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Breed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chemical Abstract Service (CAS) registry number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Engine model designation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Institutional Meat Purchase Specifications (IMPS) Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price Look-Up code (PLU)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Maritime Organization (IMO) Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bureau of Explosives 600-A (rail)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>United Nations Dangerous Goods List</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Code of Botanical Nomenclature (ICBN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Code of Zoological Nomenclature (ICZN)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>International Code of Nomenclature for Cultivated Plants</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Distributor’s article identifier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Norwegian Classification system ENVA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier assigned classification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mexican classification system AMECE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>German classification system CCG</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Finnish classification system EANFIN</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canadian classification system ICC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French classification system IFLS5</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Style number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dutch classification system CBL</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Japanese classification system JICFS</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Union dairy subsidy eligibility classification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 Spain classification system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 Poland classification system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Federal Agency on Technical Regulating and Metrology of the</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Efficient Consumer Response (ECR) Austria classification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 Italy classification system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CPV (Common Procurement Vocabulary)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IFDA (International Foodservice Distributors Association)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>AHFS (American Hospital Formulary Service) pharmacologic -</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ATC (Anatomical Therapeutic Chemical) classification system</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CLADIMED (Classification des Dispositifs Médicaux)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CMDR (Canadian Medical Device Regulations) classification</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CNDM (Classificazione Nazionale dei Dispositivi Medici)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UK DM&amp;D (Dictionary of Medicines &amp; Devices) standard coding</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>eCl@ss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EDMA (European Diagnostic Manufacturers Association)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EGAR (European Generic Article Register)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GMDN (Global Medical Devices Nomenclature)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GPI (Generic Product Identifier)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>HCPCS (Healthcare Common Procedure Coding System)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ICPS (International Classification for Patient Safety)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>MedDRA (Medical Dictionary for Regulatory Activities)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medical Columbus</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NAPCS (North American Product Classification System)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>NHS (National Health Services) eClass</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US FDA (Food and Drug Administration) Product Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SNOMED CT (Systematized Nomenclature of Medicine-Clinical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UMDNS (Universal Medical Device Nomenclature System)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>GS1 Global Returnable Asset Identifier, non-serialised</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IMEI</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Waste Type (EMSA)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship's store classification type</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Emergency fire code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Emergency spillage code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IMDG packing group</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>MARPOL Code IBC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IMDG subsidiary risk class</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport group number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Taxonomic Serial Number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>IMDG main hazard class</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EU Combined Nomenclature</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Therapeutic classification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>European Waste Catalogue</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price grouping code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UNSPSC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TSU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>EU RoHS Directive</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ultimate customer's article number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>UPC (Universal product code)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor's (seller's) part number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor's supplemental item number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vendor specification number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Payment.gc
+++ b/eu_einvoice/codelist/Payment.gc
@@ -1,0 +1,727 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Payment</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Payment</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Payment-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Remark" Use="optional">
+      <ShortName>Optional remark for the usage of this code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instrument not defined</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Automated clearing house credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Automated clearing house debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand debit reversal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand credit reversal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>6</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hold</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>National or regional clearing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>In cash</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings credit reversal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings debit reversal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bookentry credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bookentry debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand cash concentration/disbursement (CCD) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand cash concentration/disbursement (CCD) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand corporate trade payment (CTP) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cheque</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Banker's draft</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certified banker's draft</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank cheque (issued by a banking or similar establishment)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill of exchange awaiting acceptance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certified cheque</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Local cheque</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand corporate trade payment (CTP) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand corporate trade exchange (CTX) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand corporate trade exchange (CTX) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit transfer</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>non-SEPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit transfer</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>non-SEPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand cash concentration/disbursement plus (CCD+)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH demand cash concentration/disbursement plus (CCD+)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH prearranged payment and deposit (PPD)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings cash concentration/disbursement (CCD) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings cash concentration/disbursement (CCD) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings corporate trade payment (CTP) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings corporate trade payment (CTP) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings corporate trade exchange (CTX) credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings corporate trade exchange (CTX) debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings cash concentration/disbursement plus (CCD+)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment to bank account</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ACH savings cash concentration/disbursement plus (CCD+)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accepted bill of exchange</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Referenced home-banking credit transfer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interbank debit transfer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Home-banking debit transfer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank card</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Use for all payment cards</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Direct debit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment by postgiro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>FR, norme 6 97-Telereglement CFONB (French Organisation for</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Urgent commercial payment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Urgent Treasury Payment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit card</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Debit card</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bankgiro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standing agreement</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Contractual payment means</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SEPA credit transfer</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>SEPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SEPA direct debit</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>SEPA</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by the debtor</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by the debtor and endorsed by a bank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by the debtor and endorsed by a</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by a bank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by a bank and endorsed by another</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by a third party</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promissory note signed by a third party and endorsed by a</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Online payment service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transfer Advice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by the creditor on the debtor</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by the creditor on a bank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by the creditor, endorsed by another bank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by the creditor on a bank and endorsed by a</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by the creditor on a third party</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill drawn by creditor on third party, accepted and</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Not transferable banker's draft</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Not transferable local cheque</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reference giro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Urgent giro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Free format giro</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Requested method for payment was not used</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clearing between partners</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>JP, Electronically Recorded Monetary Claims</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/README.md
+++ b/eu_einvoice/codelist/README.md
@@ -1,0 +1,6 @@
+Files downloaded from https://ec.europa.eu/digital-building-blocks/sites/download/attachments/467108974/digital-genericodes-2026-05-15.zip?version=2&modificationDate=1776349554309&api=v2 , published at https://ec.europa.eu/digital-building-blocks/sites/spaces/DIGITAL/pages/467108974/Registry+of+supporting+artefacts+to+implement+EN16931#RegistryofsupportingartefactstoimplementEN16931-Codelists
+
+License: not specified. Assumed to be public domain according to the following legislation:
+
+- Art. 1(6) Open Data Directive (EU) 2019/1024
+- § 5 Abs. 2 UrhG

--- a/eu_einvoice/codelist/Text.gc
+++ b/eu_einvoice/codelist/Text.gc
@@ -1,0 +1,3241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Text</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Text</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Text-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods item description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment term</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dangerous goods additional information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dangerous goods technical name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Acknowledgement description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rate additional information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Party instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>General information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional conditions of sale/purchase</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price conditions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Goods dimensions in characters</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment re-usage restrictions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Handling restriction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Error description (free text)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Response (free text)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package content's description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Terms of delivery</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bill of lading remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mode of settlement information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment invoice information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clearance invoice information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Letter of credit information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>License information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Certification statements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional export information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tariff statements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medical history</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Conditions of sale or purchase</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract document type</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional terms and/or conditions (documentary credit)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions or information about standby documentary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions or information about partial shipment(s)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions or information about transhipment(s)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional handling instructions documentary credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Domestic routing information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chargeable category of equipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Onward routing information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accounting information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Discrepancy information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Confirmation instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Method of issuance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documents delivery instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional conditions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Information/instructions about additional amounts covered</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Deferred payment termed additional</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Acceptance terms additional</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Negotiation terms additional</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document name and documentary requirements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ABZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions/information about revolving documentary credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary requirements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Factor assignment clause</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reason</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dispute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional attribute information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Absence declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Aggregation statement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Compilation statement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Definitional exception</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Privacy statement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quality statement</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statistical description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statistical definition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statistical name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Statistical title</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Off-dimension information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unexpected stops information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Principles</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Terms and definition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Segment name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Simple data element name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Scope</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message type name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Introduction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Glossary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Functional definition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Examples</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cover page</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dependency (syntax) notes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Code value name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Code list name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clarification of usage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite data element name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Field of application</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Type of assets and liabilities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Promotion information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meter condition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Meter reading information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Type of transaction reason</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Type of survey question</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carrier's agent counter information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Description of work item on equipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Message definition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Booked item information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Source of document</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Fixed part of segment clarification text</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Characteristics of goods</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional discharge instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container stripping instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ADZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CSC (Container Safety Convention) plate information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cargo remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Temperature control instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Text refers to expected data</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Text refers to received data</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Section clarification text</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Information to the beneficiary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Information to the applicant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions to the beneficiary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions to the applicant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Controlled atmosphere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Take off annotation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price variation narrative</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentary credit amendment instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard method narrative</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Project narrative</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Radioactive goods, additional information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bank-to-bank information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AER</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reimbursement instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AES</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reason for amending a message</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions to the paying and/or accepting and/or</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interest instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agent commission</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Remitting bank instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instructions to the collecting bank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Collection amount instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AEZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Internal auditing information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Constraint</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Semantic note</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Help text</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legend</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Batch code structure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product application</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer complaint</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Probable cause of fault</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Defect description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Repair description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Review comments</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Title</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Description of amount</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Responsibilities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchase region</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Affiliation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Borrower</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Line of business</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial institution</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business founder</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business history</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Banking arrangements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business origin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AFZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Brand names' description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business financing details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Competition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Construction process details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Construction specialty</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contract information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Corporate filing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Copyright notice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Contingent debt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Conviction details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Equipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Workforce description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exemption</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Future plans</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Interviewee conversation information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intangible asset</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inventory</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Investment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intercompany relations information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Joint venture</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Long term debt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Current legal structure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marital contract</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AGZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marketing activities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Merger</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Marketable securities</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Business debt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Original legal structure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Employee sharing arrangements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Organization details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Public record details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price range</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Qualifications</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Registered activity</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Criminal sentence</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales method</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Educational institution information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Status details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Spouse information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Educational degree information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shareholding information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sales territory</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Accountant's comments</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exemption law location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Share classifications</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Forecast</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Event location</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Facility occupancy</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AHZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Import and export details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional facility information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inventory value</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Education</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AID</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Event</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Agent</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Domestically agreed financial statement details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Other current asset description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Other current liability description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AII</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Former business activity</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trade name use</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Signing authority</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Guarantee</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Holding company operation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment routing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Letter of protest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Question</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Party information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Area boundaries description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Advertisement information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Financial statement details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Access instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Liquidity</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Credit line</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warranty terms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Division description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AIZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reporting instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Examination result</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AJB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Laboratory result</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Allowance/charge information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>X-ray result</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pathology result</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intervention description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Summary of admittance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medical treatment course detail</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prognosis</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instruction to patient</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instruction to physician</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>All documents</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicine treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicine dosage and administration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Availability of patient</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reason for service request</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ALQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purpose of service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Arrival conditions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ARS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service requester's comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Authentication</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Requested location description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicine administration condition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Patient information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Precautionary measure</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service characteristic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AUZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Planned event comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Expected delay comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport requirements comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Temporary approval condition</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs Valuation Information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Value Added Tax (VAT) margin scheme</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AVF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Maritime Declaration of Health</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Passenger baggage information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Maritime Declaration of Health</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional product information address</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Information to be printed on despatch advice</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Missing goods remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Non-acceptance information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returns information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sub-line item information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Test information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>External link</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>VAT exemption reason</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Processing Instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Relay Instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA applicable</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Appeals program code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA subject</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Surtax applicable</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA security bond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Surtax subject</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safeguard applicable</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BBA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safeguard applicable</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BBB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safeguard subject</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport contract document clause</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Instruction to prepare the patient</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicine treatment comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Examination result comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Service request comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prescription reason</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Prescription comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clinical investigation comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Medicinal specification comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Economic contribution comment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Status of a plan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Random sample test information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Period of time</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Legislation</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Security measures requested</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transport contract document remark</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Previous port of call security information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Security information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Waste information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>B2C marketing information, short description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>B2B marketing information, long description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>B2C marketing information, long description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product ingredients</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Location short name</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packaging material information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Filler material information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship-to-ship activity information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package material description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BME</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consumer level package marking</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA measure in force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pre-CARM</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BMH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA measure type</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs clearance instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sub Type Code</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>SIMA information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Time limit end</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Time limit start</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehouse time limit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Value for duty information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CEX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs clearance instructions export</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CHG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Change information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs clearance instruction import</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CLP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clearance place requested</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CLR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loading remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>COI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customer remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CUS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Customs declaration information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Damage remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DCL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Document issuer declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Delivery instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DOC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Documentation instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DUT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Duty declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Effective used routing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FBC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>First block to be printed on the transport contract</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GBL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Government bill of lading information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Entire transaction set</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GS7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Further information concerning GGVS par. 7</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment handling instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HAZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hazard information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ICN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment information for consignee</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurance instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IMI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice mailing instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IND</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Commercial invoice item description</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Insurance information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Invoice instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IRP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Information for railway purpose</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ITR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Inland transport details</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ITS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Testing instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Location Alias</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Line item</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LOI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Loading instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MCO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Miscellaneous charge order</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MDH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Maritime Declaration of Health</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MKS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Additional marks/numbers information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ORI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Order instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OSI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Other service information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packing/marking information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment instructions information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payables information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PKG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packaging information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PKT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packaging terms information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PMD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment detail/remittance information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Payment information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PRD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Product information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PRF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Price calculation formula</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PRI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Priority information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Purchasing information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quarantine instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QQD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quality demands/requirements</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QUT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Quotation instruction/information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Risk and handling information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>REG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Regulatory information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Return to origin information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>REV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receivables</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RQR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment route</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Safety information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment documentary instruction</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special instructions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SLR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ship line requested</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special permission for transport, generally</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SPG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special permission concerning the goods to be transported</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SPH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special handling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SPP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special permission concerning package</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SPT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special permission concerning transport means</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SRN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Subsidiary risk number (IATA/DGR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SSR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Special service request</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Supplier remarks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TCA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment tariff</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TDT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Consignment transport</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TRA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Transportation information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TRR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Requested tariff</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TXD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tax declaration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WHI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Warehouse instruction/information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/Unit.gc
+++ b/eu_einvoice/codelist/Unit.gc
@@ -1,0 +1,17333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>Unit</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:Unit</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:Unit-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Remark" Use="optional">
+      <ShortName>Optional remark for the usage of this code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>group</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>outfit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ration</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stick, military</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>twenty foot container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>forty foot container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decilitre per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>theoretical pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>theoretical ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal square metre per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per square centimetre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce per square foot per 0,01inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sitas</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mesh</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>net kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>part per million</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent weight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>part per billion (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millipascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milli-inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per square inch absolute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>henry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot pound-force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poise</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stokes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>1I</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>fixed rate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>roentgen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt AC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt DC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2I</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2J</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2K</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2M</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2N</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decibel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2P</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2Q</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobecquerel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2R</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocurie</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2U</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megagram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2X</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2Y</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliroentgen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>2Z</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millivolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>3B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megajoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>3C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>manmonth</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centistokes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microlitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micrometre (micron)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4K</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4M</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4N</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabecquerel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4O</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microfarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4P</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4Q</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4R</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4T</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picofarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4U</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4W</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (US) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>4X</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilolitre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>5A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (US) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>5B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>batch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>5E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>MMSCF/day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>5J</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hydraulic horse power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere square metre per joule second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>angstrom</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>astronomical unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>attojoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barn</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barn per electronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barn per steradian electronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barn per steradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>becquerel per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>becquerel per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per second square foot degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per pound degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per second foot degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per hour square foot degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>candela per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb metre squared per volt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per cubic centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per cubic millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per kilogram second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per coulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>curie per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>deadweight tonnage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decalitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decametre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decitex</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>denier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>electronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>electronvolt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>electronvolt square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>electronvolt square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>8-part cloud cover</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A6</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per square metre kelvin squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exajoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>farad per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>femtojoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>femtometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot pound-force per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>freight ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigacoulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigaelectronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigahertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigaohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigaohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigapascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigawatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gray</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gray per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>henry per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>A99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ball</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bulk pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>acre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ACT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>activity</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>byte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>additional minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>average minute per call</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>fathom</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>access line</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AMP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ANN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>APZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>troy ounce or apothecary ounce</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>anti-hemophilic factor (AHF) unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>assortment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>alcoholic strength by mass</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ASU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>alcoholic strength by volume</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ATM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard atmosphere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AWG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>american wire gauge</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>assembly</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>AZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (US) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per kilogram kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per metre to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per mole kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>credit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>digit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloampere per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloampere per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobecquerel per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocoulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocoulomb per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloelectronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>batting pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gibibit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram metre squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram metre squared per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel, imperial</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per kilogram kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilonewton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilonewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilosecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilosiemens</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilosiemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloweber per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>light year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen per watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lux hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lux second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaampere per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabecquerel per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigabit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megacoulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cycle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megacoulomb per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaelectronvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megagram per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>meganewton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>meganewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megasiemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megavolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megavolt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigabit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal metre squared reciprocal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per linear foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microbar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microcoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microcoulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microcoulomb per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microfarad per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microhenry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microhenry per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micronewton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micronewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micropascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>B99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsiemens</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bar [unit of pressure]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>base box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BFT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>board foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BHP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>brake horse power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>billion (EUR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry barrel (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BLL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred board foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BPM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>beats per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BQL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>becquerel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BTU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BUA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>BUI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C0</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>call</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millifarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligray</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millihenry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millijoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre squared per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millinewton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kibibit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millinewton per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millipascal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisiemens</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisievert</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millitesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microvolt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millivolt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliwatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliwatt per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliweber</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per cubic decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanoampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanocoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanofarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanofarad per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanohenry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanohenry per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanoohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanotesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanowatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>neper</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>neper per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre squared per kilogram squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton second per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>octave</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>parsec</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>petajoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>phon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centipoise</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picoampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picocoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picofarad per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picohenry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picowatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picowatt per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt ampere hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicoulomb per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian square metre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>radian per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal angstrom</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal electron volt per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal henry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coil group</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal joule per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal kelvin or kelvin to the power minus one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal pascal or pascal to the power minus one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>C99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal second per metre squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CCT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>carrying capacity in metric ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CDL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>candela</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>card</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centigram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CKG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CLF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred leave</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centilitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CMK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CNP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CNT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cental (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>COU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CTG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>content gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CTM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metric carat</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>content ton (metric)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>curie</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CWA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred pound (cwt) / hundred weight (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>CWI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred weight (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D03</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt hour per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D04</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lot  [unit of weight]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal second per steradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>siemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mebibit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>siemens square metre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sievert</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sone</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square centimetre per erg</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square centimetre per steradian erg</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre kelvin per watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal second per steradian metre squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per joule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pen gram (protein)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per steradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per steradian joule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per volt second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>steradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terahertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terajoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terawatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terawatt hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tex</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tropical year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>unified atomic mass unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>var</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt squared per kelvin squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt - ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millivolt per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per square metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per square metre kelvin to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per steradian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per steradian square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>weber per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D6</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>roentgen per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>weber per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>minute [unit of angle]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second [unit of angle]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>book</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>round</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of words</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megacoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megajoule per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microwatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microtesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microvolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millinewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microwatt per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicoulomb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimole per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicoulomb per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicoulomb per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rem</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second per cubic metre radian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>D95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decare</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ten day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DAY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DBM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Decibel-milliwatts</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DBW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Decibel watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree [unit of angle]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decade</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decigram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decagram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decilitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DMA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decametre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DMK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DMO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard kilolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decinewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DPC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dozen piece</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DPR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dozen pair</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DPT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>displacement tonnage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DRA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dram (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DRI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dram (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DRL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dozen roll</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decitonne</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DWT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pennyweight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DZN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dozen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>DZP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dozen pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E01</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E07</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megawatt hour per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E08</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megawatt per hertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E09</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mille</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (thermochemical) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>million Btu(IT) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ping</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shares</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>TEU</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tyre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>active unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dose</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>air dry ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>strand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigabyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terabyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>petabyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pixel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapixel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dots per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gross kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>part per hundred thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram-force per square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram-force per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram-force metre per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt hour per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt hour per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>service unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>working day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>accounting unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>job</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>run foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>test</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>trip</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>use</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>well</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>zone</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exabit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exbibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pebibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tebibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gibibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mebibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kibibyte</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exbibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exbibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>exbibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigabyte per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gibibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gibibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gibibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kibibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kibibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kibibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mebibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mebibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mebibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>petabit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>petabit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pebibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pebibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pebibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terabit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>terabit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tebibit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tebibit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tebibit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bit per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bit per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per degree Celcius metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>E99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>each</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>electronic mail box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>EQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>equivalent gallon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F01</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bit per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F02</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F03</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F04</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millibar per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F05</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapascal per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F06</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poise per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F07</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F08</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound inch squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force foot per ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic decimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per kilomol</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per hertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rod [unit of distance]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micrometre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliohm per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm per mile (statute mile)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere per pound-force per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of water</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of mercury</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>water horse power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bar per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millibar per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapascal per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poise per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per litre minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per degree</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bar litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bar cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millibar litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millibar cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapascal litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapascal cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>F99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>farad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FBM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>fibre metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micromole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FIT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>failures in time</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>flake ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FNU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Formazin nephelometric unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FOT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FTK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>FTQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G01</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G04</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G05</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G06</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G08</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square inch per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G09</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stokes per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic centimetre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic decimetre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per litre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per millilitre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic centimetre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per litre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>US gallon per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force foot per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cup [unit of volume]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tablespoon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>teaspoon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Imperial gallon per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic centimetre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic decimetre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per litre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per millilitre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic centimetre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per litre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsiemens per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsiemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosiemens per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosiemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stokes per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (US) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic inch per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic inch per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic inch per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliampere per litre minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microhenry per kiloohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>G99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microhenry per ohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (US) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GBQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigabecquerel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GDW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram, dry weight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per gallon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per metre (gram per 100 centimetres)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GFI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram of fissile isotope</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GGR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>great gross</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GIA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram, including container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GII</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram, including inner packaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per millilitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GLD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry gallon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GLI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GLL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GRM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GRN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>grain</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GRO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gross</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigajoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>GWH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigawatt hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H03</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>henry per kiloohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H04</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>henry per ohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H05</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millihenry per kiloohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H06</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millihenry per ohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H07</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H08</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microbecquerel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H09</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Celsius per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square centimetre per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square decametre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square hectometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic hectometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>blank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt square inch per pound-force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per microsecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microfarad per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square micrometre (square micron)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere squared second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>farad per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hertz metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin metre per watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaohm per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaohm per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megahertz kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre watt to the power minus 0,5</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>siemens per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>teraohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt second per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>attofarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decibel per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decibel per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic decimetre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic decimetre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per square metre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per two pi radiant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per volt second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per newton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisiemens per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millivolt per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimole per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picopascal per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picosecond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per hectobar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per decakelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decapascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>module width</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>French gauge</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rack unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>big point</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>piece</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megaohm kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per ohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per degree</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per ten thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per one hundred thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per hundred</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per volt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>H99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Piece Day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HBA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectobar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HBX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred boxes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred count</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HDW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred kilogram, dry weight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HEA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HIU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred international unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HKM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred kilogram, net mass</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile per hour (statute mile)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HMO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Piece Month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>million cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectolitre of pure alcohol</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HTZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>HWE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Piece Week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch pound (pound inch)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>person</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>INQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ISD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>international sugar degree</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IUG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>international unit per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>IV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>per mille per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree API</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Baume (origin scale)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Baume (US heavy)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Baume (US light)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Balling</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Brix</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour square foot per British thermal unit (thermochemical)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour square foot per British thermal unit (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Oechsle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Rankine per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Rankine per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Rankine per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Twaddell</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micropoise</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microlitre per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>baud</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (mean)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) foot per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) inch per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) inch per second square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per pound degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) foot per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) inch per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) inch per second square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per pound degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabaud</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bar per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (UK petroleum)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (UK petroleum) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (UK petroleum) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (UK petroleum) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (UK petroleum) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (US petroleum) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>barrel (US petroleum) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (UK) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (UK) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (UK) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (UK) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (US dry) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (US dry) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (US dry) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bushel (US dry) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centinewton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centipoise per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centipoise per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (mean)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (international table) per gram degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per centimetre second degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per gram degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>clo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic centimetre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (UK fluid) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (UK fluid) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (UK fluid) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (UK fluid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>J99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (US fluid) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megajoule per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megajoule per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JNT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pipeline joint</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JOU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JPS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hundred metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>JWL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of jewels</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt demand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (US fluid) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (US fluid) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (US fluid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot pound-force per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot pound-force per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per second degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot per second psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt ampere reactive demand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (UK) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (UK) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (UK) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt ampere reactive hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gallon (US liquid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram-force per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (UK) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (UK) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (UK) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (UK) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (US) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (US) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (US) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gill (US) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard acceleration of free fall</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>grain per gallon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>horsepower (boiler)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>horsepower (electric)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per second degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per second psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobaud</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (mean)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (international table) per hour metre degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (thermochemical)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (thermochemical) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (thermochemical) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K6</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per foot hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per foot second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per cubic foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per cubic foot psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per gallon (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per hour degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per hour psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per cubic inch degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per cubic inch psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per minute degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per minute psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per second degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound (avoirdupois) per second psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per square inch degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi cubic inch per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi litre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi cubic yard per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force second per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force second per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (UK liquid) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (UK liquid) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (UK liquid) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (UK liquid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (US liquid) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>K99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (US liquid) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cake</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>katal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocharacter</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KBA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KCC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of choline chloride</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KDW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram drained net weight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KEL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KGS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KHY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of hydrogen peroxide</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KHZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilohertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per millimetre width</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram, including container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram, including inner packaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilosegment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KJO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KLK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lactic dry material percentage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KLX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilolux</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KMA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of methylamine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KMH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilometre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KMK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KNI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of nitrogen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KNM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilonewton per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KNS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram named substance</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KNT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>knot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliequivalence caustic potash per gram of product</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KPH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of potassium hydroxide (caustic potash)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KPO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of potassium oxide</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KPP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of phosphorus pentoxide (phosphoric anhydride)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloroentgen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KSD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of substance 90 % dry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KSH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of sodium hydroxide (caustic soda)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilotonne</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KUR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of uranium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KVA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt - ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KVR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KVT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilovolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kilowatt hour per normalized cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of tungsten trioxide</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kilowatt hour per standard cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KWY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>KX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (US liquid) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (US liquid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre hour degree Celsius per kilocalorie (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millipascal second per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millipascal second per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic millimetre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per kilogram kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per kilogram bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per litre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per litre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliroentgen aequivalent men</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanogram per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per gallon (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per gallon (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per cubic inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois)-force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois)-force inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picosiemens per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (UK) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (UK) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (UK) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (UK) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (US dry) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (US dry) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (US dry) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>peck (US dry) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (UK) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (UK) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (UK) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (UK) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (US liquid) per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (US liquid) per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (US liquid) per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (US liquid) per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per foot second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>slug per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per day kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per day bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per hour kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per hour bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per cubic metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per cubic metre bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per minute kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per minute bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per second kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per second bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (UK shipping)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton long per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (US shipping)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton short per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton short per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton short per hour degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton short per hour psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton short per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (UK long) per cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (US short) per cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton-force (US short)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>common year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sidereal year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>L99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per cubic inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lactose excess percentage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LBR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LBT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>troy pound (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LEF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>leaf</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>linear foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>labour hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>link</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>linear metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>length</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lot  [unit of procurement]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>liquid pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre of pure alcohol</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>layer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lump sum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (UK) or long ton (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LTR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LUB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metric ton, lubricating oil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LUM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LUX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lux</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>LY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>linear yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per psi</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilohertz metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigahertz metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Beaufort</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal megakelvin or megakelvin to the power minus one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal kilovolt - ampere reciprocal hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre per square centimetre minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton per centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent per degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gigaohm per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megahertz metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal volt - ampere reciprocal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal second per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimole per litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millivolt - ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>30-day month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>actual/360</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilometre per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>monetary value</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile (statute mile) per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>revolution</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree [unit of angle] per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>revolution per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>circular mil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square mile (based on U.S. survey foot)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>chain (based on U.S. survey foot)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microcurie</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>furlong</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot (U.S. survey)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile (based on U.S. survey foot)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per radiant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shake</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per second pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilometre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>acre-foot (based on U.S. survey foot)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cord (128 ft3)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic mile (UK statute)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>micro-inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton, register</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per cubic metre pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopound-force</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram metre per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pond</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square foot per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stokes per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square centimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per second pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>denier</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton, assay</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pfund</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per second pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne per year</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>million Btu per 1000 cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopound per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per radian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dyne metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram centimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>M99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram centimetre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megavolt ampere reactive hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megalitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megametre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megavar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MAW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megawatt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MBE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand standard brick equivalent</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MBF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand board foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MBR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millibar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MCU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicurie</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>air dry metric ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MGM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MHZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megahertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MIK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square mile (statute mile)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>minute [unit of time]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MIO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>million</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MIU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>million international unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MKD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Square Metre Day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MKM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Square Metre Month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MKW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Square Metre Week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MLD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milliard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millilitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MMK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MMQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MND</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram, dry weight</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MNJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mega Joule per Normalised cubic Metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megapascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cubic Metre Day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cubic Metre Month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MQW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cubic Metre Week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MRD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metre Day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MRM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metre Month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MRW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Metre Week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MSK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per second squared</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MTK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MTQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MTR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MTS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MTZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milihertz</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MVA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megavolt - ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>MWH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megawatt hour (1000 kW.h)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pen calorie</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound foot per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound inch per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pferdestaerke</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre of mercury (0 ºC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>centimetre of water (4 ºC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot of water (39.2 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of mercury (32 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of mercury (60 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of water (39.2 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch of water (60 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kip per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois) per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>conventional metre of water</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per square millimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per square yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot to the fourth power</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic decimetre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic foot per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>print point</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic inch per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilonewton per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal second per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poise per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton second per square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per metre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per metre minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per metre day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per metre hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gram per centimetre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>poundal second per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per foot minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per foot day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per second pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>foot poundal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>inch poundal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per square foot hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per square foot hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per square foot minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per square foot second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per square foot second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per square inch second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per square centimetre minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per square centimetre second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per cubic foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per pound degree Rankine</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocalorie (international table) per gram kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (39 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (59 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (60 ºF)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (20 ºC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quad (1015 BtuIT)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>therm (EC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>therm (U.S.)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per hour square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per second square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per second square foot degree Fahrenheit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt per square metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kelvin per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per metre degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt per metre kelvin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilowatt per metre degree Celsius</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metre per degree Celcius metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour per British thermal unit (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour per British thermal unit (thermochemical)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit second per British thermal unit (international table)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit second per British thermal unit (thermochemical)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour square foot per British thermal unit (international table) inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Fahrenheit hour square foot per British thermal unit (thermochemical) inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilofarad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal joule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picosiemens</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>franklin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ampere minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>biot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gilbert</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt per pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>N99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picovolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligram per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NAR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of articles</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NCL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of cells</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NEW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>message</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NIU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of international units</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>load</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NM3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Normalised cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NMI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nautical mile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NMP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of packs</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NPT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>number of parts</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>net ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NTU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nephelometric turbidity unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>NX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>part per thousand</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>panel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ODE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ozone depletion equivalent</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ODG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ODS Grams</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ODK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ODS Kilograms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ODM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ODS Milligrams</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OHM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce per square yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ONZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ounce (avoirdupois)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OPM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>oscillations per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>overtime hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OZA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>fluid ounce (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>OZI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>fluid ounce (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>coulomb per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloweber</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gamma</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilotesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanoohm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ohm circular-mil per foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilohenry</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lumen per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>phot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>footcandle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>candela per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>footlambert</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>lambert</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stilb</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>candela per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilocandela</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millicandela</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hefner-Kerze</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>international candle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (international table) per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>British thermal unit (thermochemical) per square foot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>calorie (thermochemical) per square centimetre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>langley</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>decade (logarithmic)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal squared second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>bel per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound mole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P45</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound mole per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P46</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound mole per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P47</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilomole per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P48</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound mole per pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P49</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton square metre per ampere</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>five pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P50</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>weber metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P51</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mol per kilogram pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P52</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mol per cubic metre pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P53</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>unit pole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P54</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligray per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P55</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgray per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P56</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanogray per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P57</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gray per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P58</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligray per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P59</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgray per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P60</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanogray per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P61</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>gray per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P62</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>milligray per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P63</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgray per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P64</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanogray per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P65</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sievert per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P66</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisievert per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P67</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsievert per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P68</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosievert per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P69</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rem per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P70</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sievert per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P71</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisievert per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P72</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsievert per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P73</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosievert per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P74</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>sievert per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P75</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millisievert per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P76</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microsievert per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P77</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanosievert per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P78</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P79</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal square metre per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P80</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>millipascal per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P81</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilopascal per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P82</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hectopascal per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P83</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard atmosphere per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P84</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>technical atmosphere per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P85</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>torr per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P86</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>psi per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P87</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic metre per second square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P88</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>rhe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P89</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force foot per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P90</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force inch per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P91</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>perm (0 ºC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P92</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>perm (23 ºC)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P93</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>byte per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P94</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilobyte per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P95</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megabyte per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P96</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal volt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P97</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal radian</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P98</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal to the power sum of stoichiometric numbers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>P99</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mole per cubiv metre to the power sum of stoichiometric numbers</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pascal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pad</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PFL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>proof litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PGL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>proof gallon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pitch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PLA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>degree Plato</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per inch of length</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>page per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pair</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound-force per square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PTD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry pint (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PTI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pint (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PTL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>liquid pint (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>PTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>portion</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q10</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>joule per tesla</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>erlang</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q12</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>octet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q13</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>octet per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q14</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shannon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q15</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hartley</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q16</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>natural unit of information</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q17</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shannon per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q18</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hartley per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q19</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>natural unit of information per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q20</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second per kilogramm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q21</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt square metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q22</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second per radian cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q23</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>weber to the power minus one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q24</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>reciprocal inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q25</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dioptre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q26</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>one per one</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q27</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>newton metre per metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q28</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram per square metre pascal second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q29</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>microgram per hectogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>meal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q30</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pH (potential of Hydrogen)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q31</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilojoule per gram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q32</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>femtolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q33</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>picolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q34</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanolitre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q35</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>megawatts per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q36</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q37</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard cubic metre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q38</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard cubic metre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q39</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Normalized cubic metre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q40</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Normalized cubic metre per hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q41</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Joule per normalised cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Q42</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Joule per standard cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>page - facsimile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quarter (of a year)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>page - hardcopy</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quire</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QTD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>dry quart (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QTI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quart (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QTL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>liquid quart (US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>QTR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>quarter (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>R1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pica</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>R9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>running or operating hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ream</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ROM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>room</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>pound per ream</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RPM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>revolutions per minute</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RPS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>revolutions per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>RT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>revenue ton mile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>S3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square foot per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>S4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square metre per second</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>half year (6 months)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SCO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>score</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SCR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>scruple</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>second [unit of time]</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SET</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>set</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>segment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SIE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>siemens</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SM3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Standard cubic metre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SMI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mile (statute mile)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SQR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square, roofing</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>strip</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stick</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stone (UK)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>stick, cigarette</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard litre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ton (US) or short ton (UK/US)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>STW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>straw</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>skein</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>shipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>SYR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>syringe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>T0</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>telecommunication line in service</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>T3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand piece</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kiloampere hour (thousand ampere hour)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TAN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>total acid number</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand square inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metric ton, including container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TIP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>metric ton, including inner packaging</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TKM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne kilometre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TMS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>kilogram of imported meat, less offal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TNE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tonne (metric ton)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ten pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TPI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>teeth per inch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TPR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ten pair</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TQD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>thousand cubic metre per day</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TRL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>trillion (EUR)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ten set</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>TTS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>ten thousand sticks</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>U1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>treatment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>U2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>tablet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>telecommunication line in service average</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>UC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>telecommunication port</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt - ampere per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>volt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>percent volume</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>W2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>wet kilo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt per kilogram</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>wet pound</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WCD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cord</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>wet ton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WEB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>weber</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WEE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>week</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>wine gallon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WHR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt hour</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>working month</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WSD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>standard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>WTT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>watt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Gunter's chain</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YDK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>square yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YDQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>cubic yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>YRD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>yard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Z11</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>hanging container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>Z9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>nanomole</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>page</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>ZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>mutually defined</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, aluminium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, plywood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container, flexible</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, fibre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X1W</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X2C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Barrel, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X3A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X3H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X43</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, super bulk</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X44</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, polybag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, aluminium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, natural wood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, plywood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, reconstituted wood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, fibreboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X4H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X5H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, woven plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X5L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, textile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X5M</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, paper</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X6H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X6P</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X7A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, car</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X7B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X8A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X8B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>X8C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bundle, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, fibre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, paper</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Aerosol</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, modular, collars 80cms * 60cms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, shrinkwrapped</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, 100cms * 110cms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Clamshell</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cone</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ball</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ampoule, non-protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ampoule, protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Atomizer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XAV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Capsule</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XB4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Belt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Barrel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bobbin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottlecrate / bottlerack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Board</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bundle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Balloon, non-protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bunch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bucket</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Basket</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bale, compressed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Basin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bale, non-compressed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottle, non-protected, cylindrical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Balloon, protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottle, protected cylindrical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottle, non-protected, bulbous</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bolt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Butt</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottle, protected bulbous</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, for liquids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Board, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XBZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bars, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Can, rectangular</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, beer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Churn</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Can, with handle and spout</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Creel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Coffer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Chest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canister</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Coffin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cask</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Coil</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Card</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container, not otherwise specified as transport equipment</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carboy, non-protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carboy, protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cartridge</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Carton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cup</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cover</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cage, roll</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Can, cylindrical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cylinder</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XCZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Canvas</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, multiple layer, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, multiple layer, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, multiple layer, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cage, Commonwealth Handling Equipment Pool  (CHEP)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, Commonwealth Handling Equipment Pool (CHEP), Eurobox</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, iron</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Demijohn, non-protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, bulk, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, bulk, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, bulk, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Dispenser</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Demijohn, protected</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, one layer no cover, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, one layer no cover, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, one layer no cover, polystyrene</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, one layer no cover, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, two layers no cover, plastic tray</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, two layers no cover, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XDY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, two layers no cover, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XED</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, with pallet base</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, with pallet base, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, with pallet base, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, with pallet base, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, with pallet base, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, isothermic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XEN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Envelope</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Flexibag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, fruit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, framed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Flexitank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Firkin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Flask</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Footlocker</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Filmpack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Frame</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Foodtainer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Cart, flatbed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XFX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, flexible container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bottle, gas</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Girder</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container, gallon</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, glass</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, containing horizontally stacked flat items</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, gunny</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XGZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Girders, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Basket, with handle, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Basket, with handle, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Basket, with handle, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hogshead</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hanger</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XHR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Hamper</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, display, wooden</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, display, cardboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, display, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XID</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, display, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, show</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, flow</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, paper wrapped</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package, cardboard, with bottle grip-holes</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray, rigid, lidded stackable (CEN TS 14482:2002)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ingot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XIZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ingots, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, jumbo</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, rectangular</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jug</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jar</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jutebag</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XJY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, cylindrical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XKG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Keg</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XKI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Kit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Luggage</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Log</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Lug</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Liftvan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XLZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Logs, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, multiply</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, milk</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XME</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sack, multi-wall</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mat</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, plastic wrapped</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XMX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Matchbox</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Not available</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unpacked or unpackaged</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unpacked or unpackaged, single unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unpacked or unpackaged, multiple units</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Nest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net, tube, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XNV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Net, tube, textile</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Two sided cage on wheels with fixing strap</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trolley</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oneway pallet ISO 0 - 1/2 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oneway pallet ISO 1 - 1/1 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oneway pallet ISO 2 - 2/1 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO6</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet with exceptional dimensions</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wooden pallet  40 cm x 80 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plastic pallet SRS 60 cm x 80 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XO9</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plastic pallet SRS 80 cm x 120 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, CHEP 40 cm x 60 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, CHEP 80 cm x 120 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, CHEP 100 cm x 120 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, AS 4068-1993</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, ISO T11</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Platform, unspecified weight or dimension</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet ISO 0 - 1/2 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet ISO 1 - 1/1 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet ISO 2 – 2/1 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>1/4 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Block</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>1/8 EURO Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Synthetic pallet ISO 1</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XON</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Synthetic pallet ISO 2</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wholesaler pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet 80 X 100 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet 60 X 100 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Oneway pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Octabin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Container, outer</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Returnable pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Large bag, pallet sized</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>A wheeled pallet with raised rim (81 x 67 x 135)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>A Wheeled pallet with raised rim (81 x 72 x 135)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XOZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wheeled pallet with raised rim ( 81 x 60 x 16)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XP1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>CHEP pallet 60 cm x 80 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XP2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pan</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XP3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LPR pallet 60 cm x 80 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XP4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>LPR pallet 80 cm x 120 cm</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Packet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, box Combined open-ended box and pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Parcel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, modular, collars 80cms * 100cms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, modular, collars 80cms * 120cms</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pen</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pitcher</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pipe</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Punnet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Package</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pail</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plank</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pouch</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Piece</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Receptacle, plastic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pot</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tray</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pipes, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Plates, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XPZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Planks, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, steel, non-removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, steel, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, aluminium, non-removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, aluminium, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, plastic, non-removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Drum, plastic, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Barrel, wooden, bung type</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Barrel, wooden, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, steel, non-removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, steel, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, plastic, non-removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Jerrican, plastic, removable head</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, wooden, natural wood, ordinary</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, wooden, natural wood, with sift proof walls</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, plastic, expanded</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XQS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Box, plastic, solid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rod</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Ring</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rack, clothing hanger</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Roll</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rednet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XRZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Rods, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slab</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Crate, shallow</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Spindle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sea-chest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sachet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Skid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, skeleton</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Slipsheet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sheetmetal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Spool</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sheet, plastic wrapping</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Case, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XST</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sheet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Suitcase</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Envelope, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Shrinkwrapped</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Set</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sleeve</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XSZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Sheets, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XT1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tablet</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tub</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tea-chest</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tube, collapsible</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tyre</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tank container, generic</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tierce</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tank, rectangular</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tub, with lid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tin</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tun</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Trunk</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, tote</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tube</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tube, with nozzle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Pallet, triwall</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tank, cylindrical</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XTZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Tubes, in bundle/bunch/truss</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XUC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Uncaged</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XUN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Unit</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vat</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, gas (at 1031 mbar and 15°C)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVI</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vial</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vanpack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, liquid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vehicle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVO</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, solid, large particles (“nodules”)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Vacuum-packed</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, liquefied gas (at abnormal temperature/pressure)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, solid, granular particles (“grains”)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, scrap metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XVY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bulk, solid, fine particles (“powders”)</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Wickerbottle</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, aluminium</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, metal</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, steel, pressurised &gt; 10 kpa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, aluminium, pressurised &gt; 10 kpa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, metal, pressure 10 kpa</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, steel, liquid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, aluminium, liquid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, metal, liquid</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, woven plastic, without coat/liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, woven plastic, coated</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, woven plastic, with liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, woven plastic, coated and liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, plastic film</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, textile with out coat/liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, natural wood, with inner liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, textile, coated</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, textile, with liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, textile, coated and liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, plywood, with inner liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XWZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, reconstituted wood, with inner liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, woven plastic, without inner coat/liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, woven plastic, sift proof</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, woven plastic, water resistant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, plastics film</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, textile, without inner coat/liner</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, textile, sift proof</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, textile, water resistant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, paper, multi-wall</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XXK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, paper, multi-wall, water resistant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in steel drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in steel crate box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in aluminium drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in aluminium crate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in wooden box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in plywood drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in plywood box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in fibre drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in fibreboard box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in plastic drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, plastic receptacle in solid plastic box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in steel drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in steel crate box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in aluminium drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in aluminium crate</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in wooden box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in plywood drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in wickerwork hamper</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in fibre drum</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in fibreboard box</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in expandable plastic pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XYZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Composite packaging, glass receptacle in solid plastic pack</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, paper, multi-wall</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZB</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Bag, large</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, paper, multi-wall, water resistant</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZD</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, with structural equipment, solids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZF</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, freestanding, solids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZG</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, with structural equipment, pressurised</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZH</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, freestanding, pressurised</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZJ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, with structural equipment, liquids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZK</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, rigid plastic, freestanding, liquids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZL</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, rigid plastic, solids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZM</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, flexible plastic, solids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZN</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, rigid plastic, pressurised</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZP</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, flexible plastic, pressurised</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZQ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, rigid plastic, liquids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZR</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite, flexible plastic, liquids</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, composite</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, fibreboard</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, flexible</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZV</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, metal, other than steel</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZW</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, natural wood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZX</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, plywood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZY</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intermediate bulk container, reconstituted wood</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>XZZ</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Mutually defined</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/codelist/VATEX.gc
+++ b/eu_einvoice/codelist/VATEX.gc
@@ -1,0 +1,847 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gc:CodeList xmlns:gc="http://docs.oasis-open.org/codelist/ns/genericode/1.0/" xmlns="">
+  <Annotation>
+    <AppInfo>
+      <ext:info xmlns:ext="urn:cef.eu:codelist:gc-annotation">This is a Digital Building Blocks for Europe Code List.
+
+This file was automatically generated.
+Do NOT edit!</ext:info>
+    </AppInfo>
+  </Annotation>
+  <Identification>
+    <ShortName>VATEX</ShortName>
+    <Version>2026-05-15</Version>
+    <CanonicalUri>urn:cef.eu:names:identifier:VATEX</CanonicalUri>
+    <CanonicalVersionUri>urn:cef.eu:names:identifier:VATEX-2026-05-15</CanonicalVersionUri>
+  </Identification>
+  <ColumnSet>
+    <Column Id="Code" Use="required">
+      <ShortName>Unique code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Name" Use="required">
+      <ShortName>Meaning of the code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Column Id="Remark" Use="optional">
+      <ShortName>Optional remark for the usage of this code</ShortName>
+      <Data Type="string" />
+    </Column>
+    <Key Id="CodeKey">
+      <ShortName>Unique code</ShortName>
+      <ColumnRef Ref="Code" />
+    </Key>
+  </ColumnSet>
+  <SimpleCodeList>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-79-C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 79, point c of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Repayment of expenditure is not an exemption in the sense of the VAT Directive but may be handled as such in the context of the EN16931.</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (a) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (b) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (c) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (d) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (e) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (f) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (g) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (h) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1I</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (i) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1J</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (j) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1K</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (k) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (l) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1M</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (m) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1N</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (n) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1O</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (o) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1P</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (p) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-132-1Q</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 132, section 1 (q) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-135-1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 135, section 1 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (a) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (b) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (c) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (d) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (e) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (f) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1FA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (fa) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (g) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1H</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (h) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1I</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (i) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1J</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (j) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1K</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (k) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-143-1L</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 143, section 1 (l) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-144</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 144 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-146-1E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 146 section 1 (e) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (a) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (b) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (c) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (d) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (e) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (f) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-148-G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 148, section (g) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (a) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1AA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (aa) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (b) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1C</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (c) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (d) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-151-1E</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 151, section 1 (e) of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-153</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 153 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-159</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 159 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-309</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 309 of Council Directive 2006/112/EC</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Reverse charge</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code AE</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-D</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Travel agents VAT scheme.</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code E</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-F</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intra-Community acquisition of second hand goods</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code E</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-G</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Export outside the EU</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code G</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-I</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intra-Community acquisition of works of art</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code E</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-IC</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intra-community supply</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code K</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-J</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Intra-Community acquisition of collectors items and antiques</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code E</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-EU-O</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Not subject to VAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only use with VAT category code O</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-FRANCHISE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>France domestic VAT franchise in base</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>For domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CNWVAT</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>For domestic Credit Notes only in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 1 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 2 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 3 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 4 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-5</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 5 of article 261 of the Code Général des Impôts (CGI ; General tax code) </SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-7</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 7 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261-8</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 8 of article 261 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 261 A of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261B</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 261 B of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261C-1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 1° of article 261 C of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261C-2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 2° of article 261 C of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261C-3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 3° of article 261 C of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261D-1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 1° of article 261 D of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261D-1BIS</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 1°bis of article 261 D of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261D-2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 2° of article 261 D of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261D-3</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 3° of article 261 D of the Code Général des Impôts (CGI ; General tax code)
+Exonération de TVA - Article 261 D-3° du Code Général des Impôts </SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261D-4</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 4° of article 261 D of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261E-1</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 1° of article 261 E of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI261E-2</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 2° of article 261 E of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI277A</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 277 A of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI275</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 275 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-298SEXDECIESA</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 298 sexdecies A of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-CGI295</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on article 295 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+    <Row>
+      <Value ColumnRef="Code">
+        <SimpleValue>VATEX-FR-AE</SimpleValue>
+      </Value>
+      <Value ColumnRef="Name">
+        <SimpleValue>Exempt based on 2 of article 283 of the Code Général des Impôts (CGI ; General tax code)</SimpleValue>
+      </Value>
+      <Value ColumnRef="Remark">
+        <SimpleValue>Only for domestic invoicing in France</SimpleValue>
+      </Value>
+    </Row>
+  </SimpleCodeList>
+</gc:CodeList>

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.js
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.js
@@ -5,6 +5,15 @@ frappe.ui.form.on("E Invoice Settings", {
 	refresh(frm) {
 		frm.trigger("set_invoice_number_field_options");
 		frm.trigger("set_auto_attach_options");
+		frm.add_custom_button(__("Import Code Lists"), () => frm.trigger("import_code_lists"));
+	},
+
+	async import_code_lists(frm) {
+		await frm.call("import_code_lists");
+		frappe.show_alert({
+			message: __("Import of code lists queued. This may take a few minutes."),
+			indicator: "green",
+		});
 	},
 
 	async set_auto_attach_options(frm) {

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -32,7 +32,12 @@ class EInvoiceSettings(Document):
 		"""Import the bundled EN 16931 code lists into an existing site."""
 		frappe.only_for("System Manager")
 		# ~4600 Common Codes, too slow for a request
-		frappe.enqueue("eu_einvoice.install.import_code_lists", queue="long", timeout=1800)
+		frappe.enqueue(
+			"eu_einvoice.install.import_code_lists",
+			queue="long",
+			timeout=1800,
+			enqueue_after_commit=True,
+		)
 
 	def before_validate(self):
 		if not self.validate_sales_invoice_on_save:

--- a/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
+++ b/eu_einvoice/european_e_invoice/doctype/e_invoice_settings/e_invoice_settings.py
@@ -27,6 +27,13 @@ class EInvoiceSettings(Document):
 		vat_exemption_reason_text: DF.SmallText | None
 	# end: auto-generated types
 
+	@frappe.whitelist()
+	def import_code_lists(self):
+		"""Import the bundled EN 16931 code lists into an existing site."""
+		frappe.only_for("System Manager")
+		# ~4600 Common Codes, too slow for a request
+		frappe.enqueue("eu_einvoice.install.import_code_lists", queue="long", timeout=1800)
+
 	def before_validate(self):
 		if not self.validate_sales_invoice_on_save:
 			self.error_action_on_save = ""

--- a/eu_einvoice/install.py
+++ b/eu_einvoice/install.py
@@ -1,7 +1,39 @@
+from pathlib import Path
+
+import frappe
+from erpnext.edi.doctype.code_list.code_list_import import (
+	import_genericode_content,
+	parse_genericode_content,
+)
+from erpnext.edi.doctype.common_code.common_code import import_genericode
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from .custom_fields import get_custom_fields
 
+CODELIST_DIR = Path(__file__).parent / "codelist"
+# All EN 16931 genericode files published by the EU share this ColumnSet.
+CODELIST_COLUMNS = {"code": "Code", "title": "Name", "description": "Remark"}
+
 
 def after_install():
 	create_custom_fields(get_custom_fields())
+	import_code_lists()
+
+
+def import_code_lists():
+	"""Import the bundled EN 16931 code lists as Code List and Common Code records."""
+	for path in sorted(CODELIST_DIR.glob("*.gc")):
+		content = path.read_bytes()
+		# Code Lists are named after their CanonicalVersionUri, so this skips
+		# already imported versions and picks up newly bundled ones.
+		version_uri = parse_genericode_content(content).findtext(".//CanonicalVersionUri")
+		if frappe.db.exists("Code List", version_uri):
+			continue
+
+		result = import_genericode_content(
+			doctype="Code List",
+			docname=None,
+			content=content,
+			file_name=path.name,
+		)
+		import_genericode(result["code_list"], result["file"], CODELIST_COLUMNS)

--- a/eu_einvoice/install.py
+++ b/eu_einvoice/install.py
@@ -16,8 +16,12 @@ CODELIST_COLUMNS = {"code": "Code", "title": "Name", "description": "Remark"}
 
 
 def after_install():
-	create_custom_fields(get_custom_fields())
+	make_custom_fields()
 	import_code_lists()
+
+
+def make_custom_fields():
+	create_custom_fields(get_custom_fields())
 
 
 def import_code_lists():

--- a/eu_einvoice/install.py
+++ b/eu_einvoice/install.py
@@ -6,6 +6,7 @@ from erpnext.edi.doctype.code_list.code_list_import import (
 	parse_genericode_content,
 )
 from erpnext.edi.doctype.common_code.common_code import import_genericode
+from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from .custom_fields import get_custom_fields
@@ -26,7 +27,10 @@ def make_custom_fields():
 
 def import_code_lists():
 	"""Import the bundled EN 16931 code lists as Code List and Common Code records."""
-	for path in sorted(CODELIST_DIR.glob("*.gc")):
+	paths = sorted(CODELIST_DIR.glob("*.gc"))
+	for i, path in enumerate(paths, start=1):
+		frappe.publish_progress(i / len(paths) * 100, title=_("Importing Code Lists"), description=path.stem)
+
 		content = path.read_bytes()
 		# Code Lists are named after their CanonicalVersionUri, so this skips
 		# already imported versions and picks up newly bundled ones.
@@ -40,4 +44,11 @@ def import_code_lists():
 			content=content,
 			file_name=path.name,
 		)
-		import_genericode(result["code_list"], result["file"], CODELIST_COLUMNS)
+		# import_genericode reports its own progress from 0 to 100 % per code list, which
+		# resets the dialog above for every file. A task id routes those events to a task
+		# room that nobody listens to, leaving one continuous progress bar.
+		frappe.local.task_id = "eu_einvoice_code_list_import"
+		try:
+			import_genericode(result["code_list"], result["file"], CODELIST_COLUMNS)
+		finally:
+			frappe.local.task_id = None

--- a/eu_einvoice/patches.txt
+++ b/eu_einvoice/patches.txt
@@ -5,7 +5,7 @@ eu_einvoice.patches.delete_custom_numbers_fields #1
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
-execute:from eu_einvoice.install import after_install; after_install() # 17
+execute:from eu_einvoice.install import make_custom_fields; make_custom_fields() # 18
 eu_einvoice.patches.set_profile_in_sales_invoice # 3
 eu_einvoice.patches.set_profile_in_import
 eu_einvoice.patches.set_default_settings

--- a/eu_einvoice/test_install.py
+++ b/eu_einvoice/test_install.py
@@ -1,0 +1,15 @@
+from lxml import etree
+
+from eu_einvoice.install import CODELIST_COLUMNS, CODELIST_DIR
+
+
+def test_bundled_codelists_match_hardcoded_column_map():
+	paths = sorted(CODELIST_DIR.glob("*.gc"))
+	assert paths, "no code lists bundled"
+
+	for path in paths:
+		root = etree.parse(str(path)).getroot()
+		columns = {c.get("Id") for c in root.findall(".//Column")}
+		assert columns <= set(CODELIST_COLUMNS.values()), f"{path.name} has unknown columns {columns}"
+		assert "Code" in columns, f"{path.name} has no Code column"
+		assert root.findtext(".//CanonicalVersionUri"), f"{path.name} has no CanonicalVersionUri"


### PR DESCRIPTION
resolves #203

Admins no longer have to import the EN 16931 code lists by hand.

The 13 genericode files published by the EU (2026-05-15) are shipped in `eu_einvoice/codelist/` and imported through ERPNext's own helpers, `import_genericode_content` and `import_genericode`, so the result is identical to a manual import in the desk UI.

## Import

- Runs `after_install` for new sites.
- Existing sites get an **Import Code Lists** button in E Invoice Settings. It enqueues the same function in the long queue, because ~4600 Common Codes are too slow for a request.
- Code Lists are named after their `CanonicalVersionUri`, so an already imported version is skipped. Repeated runs do nothing, and a newer bundled version is picked up automatically.
- The `ColumnSet` is hardcoded as `Code` / `Name` / `Remark`, which all 13 files share. `test_install.py` fails if a file is added that declares another column.

## Notes

- `patches.txt` now calls `make_custom_fields` instead of `after_install`, so bumping the patch counter later cannot trigger a code list import by accident.
- `import_genericode` reports progress from 0 to 100 % per code list, which reset the progress dialog for every file. Setting `frappe.local.task_id` routes those events to a task room that nobody listens to, leaving one continuous bar over all files.
